### PR TITLE
Bug 1880330 - only link to dashboards for supported surfaces

### DIFF
--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -1,0 +1,19 @@
+import { isAboutWelcomeTemplate } from '../../lib/messageUtils'
+
+describe('isAboutWelcomeTemplate', () => {
+  it('returns true if a feature_callout', () => {
+    const sampleSurface = "feature_callout"
+
+    const result = isAboutWelcomeTemplate(sampleSurface)
+
+    expect(result).toBeTruthy()
+  })
+
+  it("returns false if an infobar", () => {
+    const sampleSurface = "infobar"
+
+    const result = isAboutWelcomeTemplate(sampleSurface)
+
+    expect(result).toBeFalsy()
+  })
+})

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -43,7 +43,7 @@ export type FxMSMessageInfo = {
   segment: string
   ctrPercent: number
   ctrPercentChange: number
-  ctrDashboardLink: string
+  ctrDashboardLink?: string
   previewLink: string
   metrics: string
 }
@@ -116,7 +116,10 @@ export const fxmsMessageColumns: ColumnDef<FxMSMessageInfo>[] = [
     accessorKey: "metrics",
     header: "Metrics",
     cell: (props: any) => {
-      return OffsiteLink(props.row.original.ctrDashboardLink, "Results");
+      if (props.row.original.ctrDashboardLink) {
+        return OffsiteLink(props.row.original.ctrDashboardLink, "Dashboard");
+      }
+      return ( <></> );
     }
   }, {
     accessorKey: "previewLink",

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -27,3 +27,11 @@ export function getTemplateFromMessage(msg : any) : string {
 
   return msg.template;
 }
+
+export function isAboutWelcomeTemplate( template : string ) : boolean {
+  // XXX multi shouldn't really be here, but for now, we're going to assume
+  // it's a spotlight
+  const aboutWelcomeSurfaces = ['feature_callout', 'multi', 'spotlight']
+
+  return aboutWelcomeSurfaces.includes(template);
+}


### PR DESCRIPTION
Previously, we were linking to dashboards that didn't support the surfaces of the messages (i.e., linking to incorrect non-result dashboards).  This removes those links.