### PR TITLE
Bug 1880335 - used proposedDuration when needed

### DIFF
--- a/__tests__/lib/experimentUtils.test.ts
+++ b/__tests__/lib/experimentUtils.test.ts
@@ -1,0 +1,48 @@
+import { getProposedEndDate } from '../../lib/experimentUtils.ts'
+
+describe('getProposedEndDate', () => {
+  it('returns the same date if the proposed duration is 0', () => {
+    const startDate : string = "2020-01-01"
+    const proposedDuration : number = 0
+
+    const result = getProposedEndDate(startDate, proposedDuration)
+
+    expect(result).toBe(startDate)
+  })
+
+  it('returns a date in the next month if appropriate', () => {
+    const startDate : string = "2020-01-01"
+    const proposedDuration : number = 32
+
+    const result = getProposedEndDate(startDate, proposedDuration)
+
+    expect(result).toBe("2020-02-02")
+  })
+
+  it('returns a date in the next year if appropriate', () => {
+    const startDate : string = "2021-12-01"
+    const proposedDuration : number = 32
+
+    const result = getProposedEndDate(startDate, proposedDuration)
+
+    expect(result).toBe("2022-01-02")
+  })
+
+  it('returns null if startDate is null', () => {
+    const startDate : string | null = null
+    const proposedDuration : number = 32
+
+    const result = getProposedEndDate(startDate, proposedDuration)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null if proposedDuration is undefined', () => {
+    const startDate : string | null = "2021-12-01";
+    const proposedDuration : number | undefined = undefined;
+
+    const result = getProposedEndDate(startDate, proposedDuration)
+
+    expect(result).toBeNull()
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { BranchInfo, ExperimentAndBranchInfo, ExperimentInfo, experimentColumns,
 import { getDisplayNameForTemplate, getTemplateFromMessage, isAboutWelcomeTemplate } from "../lib/messageUtils.ts";
 
 import { MessageTable } from "./message-table";
-import { usesMessagingFeatures } from "../lib/experimentUtils.ts";
+import { getProposedEndDate, usesMessagingFeatures } from "../lib/experimentUtils.ts";
 import Link from "next/link";
 
 function getASRouterLocalColumnFromJSON(messageDef: any) : FxMSMessageInfo {
@@ -119,7 +119,9 @@ function getExperimentAndBranchInfoFromRecipe(recipe: NimbusExperiment) : Experi
 
   let experimentInfo : ExperimentInfo = {
     startDate: recipe.startDate || undefined,
-    endDate: recipe.endDate || undefined, // XXX use proposed duration instead
+    endDate:
+      recipe.endDate ||
+      getProposedEndDate(recipe.startDate, recipe.proposedDuration) || undefined,
     product: 'Desktop',
     release: 'Fx Something',
     id: recipe.slug,

--- a/lib/experimentUtils.ts
+++ b/lib/experimentUtils.ts
@@ -40,7 +40,29 @@ export function usesMessagingFeatures(recipe : NimbusExperiment): boolean {
   // XXX figure out how to better handle the ?
   let featureId : string = (recipe as any)?.featureIds[0];
   if (MESSAGING_EXPERIMENTS_DEFAULT_FEATURES.includes(featureId)) {
-      return true;
+    return true;
   }
   return false;
+}
+
+/**
+ *
+ * @param startDate - may be null, as NimbusExperiment types allow this.
+ *                    returns null in this case.
+ * @param proposedDuration - may be undefined as NimbusExperiment types
+ *                    allow this.  returns null in this case.
+ */
+export function getProposedEndDate (startDate : string | null, proposedDuration : number | undefined) : string | null {
+
+  if (startDate === null || proposedDuration === undefined) {
+    return null
+  }
+
+  // XXX need to verify that experimenter actually uses UTC here
+  const jsDate = new Date(startDate)
+
+  jsDate.setUTCDate(jsDate.getUTCDate() + proposedDuration)
+  const formattedDate = jsDate.toISOString().slice(0, 10)
+
+  return formattedDate
 }


### PR DESCRIPTION
Many (most? all?) live experiments have their endDate unset in the JSON.  However, we do want to display the proposed end date for live experiments. This computes that date using the startDate and the proposedDuration, and causes that to be rendered in the dashboard if the endDate is not present.