### PR TITLE
Bug 1880564 - make Skylight exp dates skimmable

### DIFF
--- a/__tests__/app/dates.test.tsx
+++ b/__tests__/app/dates.test.tsx
@@ -1,17 +1,27 @@
 import { render, screen } from '@testing-library/react'
-import { Dates } from '../../app/dates'
+import { PrettyDateRange } from '../../app/dates'
 
-describe('Dashboard', () => {
-  it('renders a Dates element', () => {
+describe('PrettyDateRange', () => {
+  it("should render a pretty version of the range", () => {
     const startDate = "2024-02-01"
     const endDate = "2024-02-04"
 
-    render(<Dates startDate={startDate} endDate={endDate} />)
+    render(<PrettyDateRange startDate={startDate} endDate={endDate} />)
 
-    const renderedStartDate = screen.getByText(startDate, {exact: false})
-    const renderedEndDate = screen.getByText(endDate, {exact: false})
+    const part1 = screen.getByText("Feb 1-")
+    expect(part1).toBeInTheDocument()
+    const part2 = screen.getByText("Feb 4")
+    expect(part2).toBeInTheDocument()
+  })
 
-    expect(renderedStartDate).toBeInTheDocument()
-    expect(renderedEndDate).toBeInTheDocument()
+  it("should not convert a null date to Jan 1", () => {
+    const startDate = "2024-02-02"
+    const endDate : string | null = null
+
+    render(<PrettyDateRange startDate={startDate} endDate={endDate} />)
+
+    // use queryByText to avoid throwing when it's not there
+    const secondDate = screen.queryByText("Jan 1", {exact: false})
+    expect(secondDate).not.toBeInTheDocument()
   })
 })

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -3,7 +3,7 @@ import { types } from "@mozilla/nimbus-shared";
 import { ColumnDef } from "@tanstack/react-table";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Copy } from "lucide-react";
-import { Dates} from "./dates";
+import { PrettyDateRange } from "./dates";
 import {
   Tooltip,
   TooltipContent,
@@ -64,8 +64,8 @@ export type ExperimentInfo = {
   previewLink?: string
   metrics?: string
   experimenterLink?: string
-  startDate?: string
-  endDate?: string
+  startDate: string | null
+  endDate: string | null
   userFacingName?: string
   recipe?: NimbusExperiment
   isBranch?: boolean
@@ -176,7 +176,7 @@ export const experimentColumns: ColumnDef<ExperimentAndBranchInfo>[] = [
     header: "Dates",
     cell: (props: any) => {
       return (
-        <Dates startDate={props.row.original.startDate}
+        <PrettyDateRange startDate={props.row.original.startDate}
           endDate={props.row.original.endDate} />
       );
     }

--- a/app/dates.tsx
+++ b/app/dates.tsx
@@ -1,15 +1,32 @@
 type DatesProps = {
-  startDate?: string
-  endDate?: string
+  startDate: string | null
+  endDate: string | null
 }
 
-export function Dates({startDate, endDate} : DatesProps) {
+function toPrettyDate(dateString : string | null) : string | null {
+    if (!dateString) {
+      return null;
+    }
+
+    let dateObj = new Date(dateString);
+
+    return dateObj.toLocaleDateString("en-US", {
+      month: "short", day: "numeric", timeZone: "UTC"
+    });
+}
+
+export function PrettyDateRange({startDate, endDate} : DatesProps) {
   if (startDate || endDate) {
     return (
       <>
-        {startDate} - {endDate}
+        <div className="font-normal text-stone-600 text-base">
+          {toPrettyDate(startDate)}-
+        </div>
+        <div className="font-normal text-stone-600 text-base">
+          {toPrettyDate(endDate)}
+        </div>
       </>
     )
   }
-  return ( <></>)
+  return ( <></> )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,10 +118,10 @@ function getExperimentAndBranchInfoFromRecipe(recipe: NimbusExperiment) : Experi
   };
 
   let experimentInfo : ExperimentInfo = {
-    startDate: recipe.startDate || undefined,
+    startDate: recipe.startDate || null,
     endDate:
       recipe.endDate ||
-      getProposedEndDate(recipe.startDate, recipe.proposedDuration) || undefined,
+      getProposedEndDate(recipe.startDate, recipe.proposedDuration) || null,
     product: 'Desktop',
     release: 'Fx Something',
     id: recipe.slug,


### PR DESCRIPTION
This makes the dates more readable and skimmable.  It also contains some type fixes to match the NimbusExperiment types used for dates.