### PR TITLE
Bug 1880334 - Add infobar dashboards

### DIFF
--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -1,10 +1,10 @@
-import { isAboutWelcomeTemplate } from '../../lib/messageUtils'
+import { _isAboutWelcomeTemplate } from '../../lib/messageUtils'
 
 describe('isAboutWelcomeTemplate', () => {
   it('returns true if a feature_callout', () => {
     const sampleSurface = "feature_callout"
 
-    const result = isAboutWelcomeTemplate(sampleSurface)
+    const result = _isAboutWelcomeTemplate(sampleSurface)
 
     expect(result).toBeTruthy()
   })
@@ -12,7 +12,7 @@ describe('isAboutWelcomeTemplate', () => {
   it("returns false if an infobar", () => {
     const sampleSurface = "infobar"
 
-    const result = isAboutWelcomeTemplate(sampleSurface)
+    const result = _isAboutWelcomeTemplate(sampleSurface)
 
     expect(result).toBeFalsy()
   })

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -28,10 +28,25 @@ export function getTemplateFromMessage(msg : any) : string {
   return msg.template;
 }
 
-export function isAboutWelcomeTemplate( template : string ) : boolean {
+export function _isAboutWelcomeTemplate( template : string ) : boolean {
   // XXX multi shouldn't really be here, but for now, we're going to assume
   // it's a spotlight
   const aboutWelcomeSurfaces = ['feature_callout', 'multi', 'spotlight']
 
   return aboutWelcomeSurfaces.includes(template);
+}
+
+export function getDashboard( template: string, msgId: string ) : string | undefined {
+  const encodedMsgId = encodeURIComponent(msgId);
+  const encodedTemplate = encodeURIComponent(template);
+
+  if (_isAboutWelcomeTemplate(template)) {
+    return `https://mozilla.cloud.looker.com/dashboards/1471?Message+ID=%25${encodedMsgId?.toUpperCase()}%25`
+  }
+
+  if (template === 'infobar') {
+    return `https://mozilla.cloud.looker.com/dashboards/1622?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+days&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=release&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=`
+  }
+
+  return undefined
 }


### PR DESCRIPTION
This cleans up the dashboard link creation code, and adds a link to the newly created infobar dashboard (based on the messaging explore, unlike the about:welcome dashboards, which are based on the event counts explore.

It would be great to have once over on the dashboard itself as part of this review to convince ourselves that it's showing accurate stuff.
