### PR TITLE
Prevent wrapping of dates and OffsiteLinks that looked odd, no bug

### DIFF
--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -13,7 +13,7 @@ import {
 
 function OffsiteLink(href: string, linkText: string) {
   return (
-    <a href={href} className="text-xs/[180%]" target="_blank" rel="noreferrer">
+    <a href={href} className="text-xs/[180%] whitespace-nowrap" target="_blank" rel="noreferrer">
       {linkText}
       <svg
         fill="none"

--- a/app/dates.tsx
+++ b/app/dates.tsx
@@ -19,10 +19,10 @@ export function PrettyDateRange({startDate, endDate} : DatesProps) {
   if (startDate || endDate) {
     return (
       <>
-        <div className="font-normal text-stone-600 text-base">
+        <div className="font-normal text-stone-600 text-base whitespace-nowrap">
           {toPrettyDate(startDate)}-
         </div>
-        <div className="font-normal text-stone-600 text-base">
+        <div className="font-normal text-stone-600 text-base whitespace-nowrap">
           {toPrettyDate(endDate)}
         </div>
       </>


### PR DESCRIPTION
This prevents the dates from wrapping in weird places, and the OffsiteLink icon from wrapping to be on a different line than the link text.