### PR TITLE
Bug 1883814 - clarify Skylight visual hierarchy by indenting branches

### DIFF
--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -180,7 +180,7 @@ export const experimentColumns: ColumnDef<ExperimentAndBranchInfo>[] = [
       }
 
       return (
-          <div className="font-mono text-xs">
+          <div className="font-mono text-xs ps-6">
             {props.row.original.id}
           </div>
       );


### PR DESCRIPTION
Adds a bit of padding to the start of branch cells.