### PR TITLE
Bug 1887077: filter on experiments & branches, enable about:welcome dashboards, temporarily disable infobar dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Monday, April 8th, 2024
+
+### Added
+
+* about:welcome dashboards turned on for experiments
+
+### Fixed
+
+* Fixed all about:welcome-based surface experiment dashboards
+  incorrectly showing data for everything with the given message id
+  instead of just the correct branch & experiment.
+
 ## Monday, April 1st, 2024
 
 ### Added

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -58,14 +58,16 @@ describe('toBinary', () => {
 })
 
 describe('getDashboard', () => {
-  it('returns a correct infobar dashboard link', () => {
+  it('returns a correct infobar dashboard link w/exp & branch', () => {
     const template = "infobar"
-    const msgId = "123"
-    const channel = "rel:ease" // weird chars test URI encoding
+    const msgId = "12`3" // weird chars to test URI encoding
+    const channel = "release"
+    const experiment = "experiment:test"
+    const branchSlug = "treatment:a"
 
-    const result = getDashboard(template, msgId, channel)
+    const result = getDashboard(template, msgId, channel, experiment, branchSlug)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1622?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30+days&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1682?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30+days&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`
     expect(result).toEqual(expectedLink)
   })
 
@@ -73,9 +75,22 @@ describe('getDashboard', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1471?Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId)
+    expect(result).toEqual(expectedLink)
+  });
+
+  // XXX should this be "about:welcome" to be consistent with featureIds?
+  it('returns a correct aboutwelcome dashboard link w/exp & branch', () => {
+    const template = "aboutwelcome"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const experiment = "experiment:test"
+    const branchSlug = "treatment:a"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
+
+    const result = getDashboard(template, msgId, undefined, experiment, branchSlug)
     expect(result).toEqual(expectedLink)
   });
 

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -67,7 +67,7 @@ export type RecipeInfo = {
   startDate: string | null
   endDate: string | null
   userFacingName?: string
-  nimbusExperiment?: NimbusExperiment
+  nimbusExperiment: NimbusExperiment
   isBranch?: boolean
 } | []
 
@@ -87,7 +87,7 @@ export type BranchInfo = {
   startDate?: string
   endDate?: string
   userFacingName?: string
-  nimbusExperiment?: NimbusExperiment
+  nimbusExperiment: NimbusExperiment
   isBranch?: boolean
   template?: string
 } | []
@@ -221,8 +221,11 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
         return ( <></> );
       }
 
-      // XXX We need to handle similarly named branches and filter by experiment slug
-      if (props.row.original.ctrDashboardLink) {
+
+      // XXX see https://bugzilla.mozilla.org/show_bug.cgi?id=1890055 for
+      // re-enabling infobar code.
+      if (props.row.original.ctrDashboardLink &&
+          props.row.original.template !== 'infobar') {
         return OffsiteLink(props.row.original.ctrDashboardLink, "Dashboard");
       }
       return ( <></> );

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -32,6 +32,7 @@ export function _isAboutWelcomeTemplate(template: string): boolean {
   // XXX multi shouldn't really be here, but for now, we're going to assume
   // it's a spotlight
   const aboutWelcomeSurfaces = [
+    "aboutwelcome",
     "feature_callout",
     "multi",
     "spotlight",
@@ -44,19 +45,22 @@ export function _isAboutWelcomeTemplate(template: string): boolean {
 export function getDashboard(
   template: string,
   msgId: string,
-  channel?: string): string | undefined {
+  channel?: string,
+  experiment?: string,
+  branchSlug?: string): string | undefined {
+
   const encodedMsgId = encodeURIComponent(msgId);
   const encodedTemplate = encodeURIComponent(template);
   const encodedChannel = channel ? (encodeURIComponent(channel)) : "";
+  const encodedExperiment = experiment ? (encodeURIComponent(experiment)) : "";
+  const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
 
   if (_isAboutWelcomeTemplate(template)) {
-    //XXX we need to return something different for the actual about:welcome experiments, due to
-    // branches having names in common (i.e. 'treatment-a')
-    return `https://mozilla.cloud.looker.com/dashboards/1471?Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}`;
+    return `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/1622?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+days&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=`;
+    return `https://mozilla.cloud.looker.com/dashboards/1682?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+days&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
   }
 
   return undefined;

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -73,10 +73,9 @@ export class NimbusRecipe implements NimbusRecipeType {
 
     switch (template) {
       case "aboutwelcome":
-        // Make sure there's a message to preview, bail out early otherwise
-        if (!feature.value.screens) {
-          break;
-        }
+
+        branchInfo.id = feature.value.id
+
         // featureValue will become the "content" object in a spotlight JSON
         let spotlightFake = {
           id: this._rawRecipe.id,
@@ -106,8 +105,7 @@ export class NimbusRecipe implements NimbusRecipeType {
         break
 
       case 'infobar':
-        branchInfo.id = feature.value.messages[0].id
-        branchInfo.ctrDashboardLink = getDashboard(template, branchInfo.id)
+        branchInfo.id = feature.value.id
         // Localize the recipe if necessary.
         // XXX [Object.keys(recipe.localizations)[0]] accesses the first locale inside the localization object.
         // We'll probably want to add a dropdown component that allows us to choose a locale from the available ones, to pass to this function.
@@ -164,7 +162,8 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         break
     }
 
-    branchInfo.ctrDashboardLink = getDashboard(branch.template, branchInfo.id)
+    branchInfo.ctrDashboardLink =
+      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug)
 
     if (!feature.value.content) {
       console.log("v.content is null")


### PR DESCRIPTION
Fixed all about:welcome-based surface experiment dashboards incorrectly showing data for everything with the given message id instead of just the correct branch & experiment [bug 1887077](https://bugzilla.mozilla.org/show_bug.cgi?id=1887077).

We've now turned on dashboards for the about:welcome onboarding surface.

This issue has also (we believe) been fixed for infobar experiment dashboards as well, but we will enable those later in [bug 1890055](https://bugzilla.mozilla.org/show_bug.cgi?id=1890055) once we've had a chance to test it more.

Jointly coded and reviewed by @AllegroFox and @dmose.
