### PR TITLE
Bug 1891093 - Switch from Remote Settings to Experimenter API

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,10 @@
 # .env
 
-# Remote settings records URL
-RECORDS_URL="https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/"
+# Base URL for the experimenter API (defaults to the production instance)
+#
+EXPERIMENTER_API_PREFIX="https://experimenter.services.mozilla.com/api/v7/"
 
-#Collection 
-COLLECTION="nimbus-desktop-experiments/records"
+# API call with parameters to fetch experiments we want to display.
+# https://htmlpreview.github.io/?https://github.com/mozilla/experimenter/blob/main/docs/experimenter/swagger-ui.html has more info.
+#
+EXPERIMENTER_API_CALL="experiments/?status=Live&application=firefox-desktop"

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,4 @@
 # Copy this to .env.local to set local variables
 
-# Nimbus recipe collection (defaults to prod)
-
 # Preview
-# COLLECTION="nimbus-preview/records"
+# EXPERIMENTER_API_CALL="experiments/?status=Preview&application=firefox-desktop"

--- a/README.md
+++ b/README.md
@@ -6,13 +6,10 @@ A bunch of the code, ideas, and links come from the OMC team's work week Hackath
 
 1. Copy the sample env file
 
-    cp .env.sample .env.local
+    `cp .env.sample .env.local`
 
-1. Modify variables in .env.local, e.g.
-
-    COLLECTION="nimbus-desktop-experiments/records"
-
-To switch between the prod and preview collections, uncomment the appropriate line in .env.local.
+1. Modify variables in .env.local, e.g. uncommenting the `EXPERIMENTER_API_CALL`
+   line will switch from the default of live experiments to preview experiments
 
 ## Running the development server
 

--- a/__tests__/lib/nimbusRecipeCollection.test.ts
+++ b/__tests__/lib/nimbusRecipeCollection.test.ts
@@ -5,7 +5,7 @@ import { ExperimentFakes } from '@/__tests__/ExperimentFakes.mjs'
 const fakeFetchData = [ExperimentFakes.recipe()]
 global.fetch = jest.fn(() =>
   Promise.resolve({
-    json: () => Promise.resolve({ data: fakeFetchData }),
+    json: () => Promise.resolve(fakeFetchData),
   }),
 ) as jest.Mock;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import { types } from "@mozilla/nimbus-shared";
 import { BranchInfo, RecipeOrBranchInfo, experimentColumns, FxMSMessageInfo, fxmsMessageColumns } from "./columns";
 import { getDashboard, getDisplayNameForTemplate, getTemplateFromMessage, _isAboutWelcomeTemplate, getPreviewLink } from "../lib/messageUtils.ts";
-import { NimbusRecipeCollection } from '@/lib/nimbusRecipeCollection'
+import { NimbusRecipeCollection } from "../lib/nimbusRecipeCollection"
 import { _substituteLocalizations } from "../lib/experimentUtils.ts";
 
 import { NimbusRecipe } from "../lib/nimbusRecipe.ts"

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -1,5 +1,5 @@
 import { types } from "@mozilla/nimbus-shared"
-import { NimbusRecipe } from '@/lib/nimbusRecipe'
+import { NimbusRecipe } from "../lib/nimbusRecipe"
 type NimbusExperiment = types.experiments.NimbusExperiment
 
 type NimbusRecipeCollectionType = {
@@ -15,15 +15,18 @@ export class NimbusRecipeCollection implements NimbusRecipeCollectionType {
   }
 
   async fetchRecipes() : Promise<Array<NimbusRecipe>> {
-      const response = await fetch(
-      `${process.env.RECORDS_URL}${process.env.COLLECTION}`,
+    const experimenterUrl = `${process.env.EXPERIMENTER_API_PREFIX}${process.env.EXPERIMENTER_API_CALL}`
+
+    // console.log("experimenterURL = ", experimenterUrl)
+    const response = await fetch(experimenterUrl,
       {
         credentials: "omit",
       }
-    );
-    const responseJSON = await response.json();
-    const experiments : NimbusExperiment[] = await responseJSON.data;
+    )
+    // console.log("response = ", response)
+    const experiments : NimbusExperiment[] = await response.json()
 
+    // console.log('returned experiments', experiments)
     this.recipes = experiments.map(
       (nimbusExp : NimbusExperiment) => new NimbusRecipe(nimbusExp)
     )


### PR DESCRIPTION
Bug 1891093 - switch from pulling info from remote settings to pulling it from the Experiment API so that we can get user-friendly branch names and fix broken screenshot links.