### PR TITLE
Make dependabot update most nextjs packages together

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: "npm" # See documentation for possible values
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "daily"
+    # group the main nextjs packages group as one PR, since they're
+    # created together and are annoying to update separately.  Unfortunately,
+    # they're not scoped under @next, so we'll need to add anything
+    # from https://github.com/vercel/next.js/tree/canary/packages
+    # that's not captured by "*next*" and isn't a dep of an existing top-level
+    # package we use if we start using it.
+    groups:
+          next:
+            applies-to: version-updates
+            patterns:
+            - "*next*"
+            update-types:
+            - "minor"
+            - "patch"


### PR DESCRIPTION
 Group the main nextjs packages group as one PR, since they're created together and are annoying to update separately.  Unfortunately, they're not scoped under @next, so we'll need to add anything from https://github.com/vercel/next.js/tree/canary/packages that's not captured by "*next*" and isn't a dep of an existing top-level package we use if we start using it.