### PR TITLE
Bug 1891100 - Only render existing screenshot links

### DIFF
--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -87,6 +87,7 @@ export type BranchInfo = {
   nimbusExperiment: NimbusExperiment
   isBranch?: boolean
   template?: string
+  screenshots?: string[]
 } | []
 
 export type RecipeOrBranchInfo = RecipeInfo | BranchInfo;
@@ -229,11 +230,11 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
         // XXX should figure out how to do this NimbusRecipe instantiation
         // once per row (maybe useState?)
         const recipe = new NimbusRecipe(props.row.original.nimbusExperiment)
-        const branchLink = recipe.getBranchScreenshotsLink(
-            props.row.original.slug);
-        return (
-          OffsiteLink(branchLink, "Screenshots")
-        )
+        const branchLink =
+          props.row.original.screenshots.length > 0
+            ? recipe.getBranchScreenshotsLink(props.row.original.slug)
+            : null;
+        return branchLink ? OffsiteLink(branchLink, "Screenshots") : null;
       }
 
       return (

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -230,11 +230,13 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
         // XXX should figure out how to do this NimbusRecipe instantiation
         // once per row (maybe useState?)
         const recipe = new NimbusRecipe(props.row.original.nimbusExperiment)
-        const branchLink =
-          props.row.original.screenshots.length > 0
-            ? recipe.getBranchScreenshotsLink(props.row.original.slug)
-            : null;
-        return branchLink ? OffsiteLink(branchLink, "Screenshots") : null;
+        
+        if (props.row.original.screenshots.length > 0) {
+          const branchLink = recipe.getBranchScreenshotsLink(props.row.original.slug)
+          return OffsiteLink(branchLink, "Screenshots")
+        } else {
+          return null
+        }
       }
 
       return (

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -49,7 +49,8 @@ export class NimbusRecipe implements NimbusRecipeType {
         // the client by NextJS (but classes can't), and any
         // needed NimbusRecipe class rewrapping can be done there.
         nimbusExperiment: this._rawRecipe,
-        slug: branch.slug
+        slug: branch.slug,
+        screenshots: branch.screenshots
       }
 
     // XXX right now we don't support more than one messaging feature


### PR DESCRIPTION
Bug 1891100

Changes made:
- Checks that the experiment branch's `screenshots` property is non-empty and only renders the screenshot links in that case
