### PR TITLE
Bug 1891083 - Make Skylight table titles clearer

### DIFF
--- a/__tests__/components/ui/infoicon.test.tsx
+++ b/__tests__/components/ui/infoicon.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InfoIcon } from "@/components/ui/infoicon.tsx";
+
+describe("InfoIcon", () => {
+  const iconSize = 16;
+  const content = "This is a test string for the tooltip content.";
+
+  it("renders an InfoIcon button", () => {
+    render(<InfoIcon iconSize={iconSize} content={content} />);
+    const infoIconButton = screen.getByRole("button");
+    expect(infoIconButton).toBeInTheDocument();
+  });
+
+  it("displays tooltip content on focus", () => {
+    render(<InfoIcon iconSize={iconSize} content={content} />);
+    const infoIconButton = screen.getByRole("button");
+    fireEvent.focus(infoIconButton)
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  })
+});

--- a/__tests__/components/ui/infoicon.test.tsx
+++ b/__tests__/components/ui/infoicon.test.tsx
@@ -7,6 +7,7 @@ describe("InfoIcon", () => {
 
   it("renders an InfoIcon button", () => {
     render(<InfoIcon iconSize={iconSize} content={content} />);
+    
     const infoIconButton = screen.getByRole("button");
     expect(infoIconButton).toBeInTheDocument();
   });
@@ -14,7 +15,9 @@ describe("InfoIcon", () => {
   it("displays tooltip content on focus", () => {
     render(<InfoIcon iconSize={iconSize} content={content} />);
     const infoIconButton = screen.getByRole("button");
+
     fireEvent.focus(infoIconButton)
+
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
   })
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { getDashboard, getDisplayNameForTemplate, getTemplateFromMessage, _isAbo
 import { NimbusRecipeCollection } from "../lib/nimbusRecipeCollection"
 import { _substituteLocalizations } from "../lib/experimentUtils.ts";
 
+import { InfoButton } from "@/components/ui/infobutton.tsx";
 import { NimbusRecipe } from "../lib/nimbusRecipe.ts"
 import { MessageTable } from "./message-table";
 import Link from "next/link";
@@ -111,17 +112,23 @@ export default async function Dashboard() {
         </ul>
       </div>
 
-      <h5 className="scroll-m-20 text-xl font-semibold text-center py-4">
-        Production Messages - Release Channel (*)
+      <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
+        Messages Released on Firefox
+      </h5>
+      <h5 className="scroll-m-20 text-lg font-semibold text-center">
+        (Partial List) 
+        <InfoButton />
       </h5>
 
       <div className="container mx-auto py-10">
         <MessageTable columns={fxmsMessageColumns} data={localData} />
       </div>
 
-      <h5 className="scroll-m-20 text-xl font-semibold text-center py-4">
-        Live Message Experiments: &nbsp;
-          {totalExperiments} total
+      <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
+        Current Message Experiments
+      </h5>
+      <h5 className="scroll-m-20 text-lg font-semibold text-center">
+        Total: {totalExperiments}
       </h5>
 
       <div className="container mx-auto py-10">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { getDashboard, getDisplayNameForTemplate, getTemplateFromMessage, _isAbo
 import { NimbusRecipeCollection } from "../lib/nimbusRecipeCollection"
 import { _substituteLocalizations } from "../lib/experimentUtils.ts";
 
-import { InfoButton } from "@/components/ui/infobutton.tsx";
+import { InfoIcon } from "@/components/ui/infoicon.tsx";
 import { NimbusRecipe } from "../lib/nimbusRecipe.ts"
 import { MessageTable } from "./message-table";
 import Link from "next/link";
@@ -114,10 +114,13 @@ export default async function Dashboard() {
 
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
         Messages Released on Firefox
+        <InfoIcon
+          iconSize={16}
+          content="All messages listed in this table are in the release channel and are either currently live or have been live on Firefox at one time."
+        />
       </h5>
       <h5 className="scroll-m-20 text-lg font-semibold text-center">
         (Partial List) 
-        <InfoButton />
       </h5>
 
       <div className="container mx-auto py-10">

--- a/components/ui/infobutton.tsx
+++ b/components/ui/infobutton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function InfoButton() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            className={buttonVariants({
+              variant: "secondary",
+              size: "sm",
+              className: "bg-background p-1 hover:text-primary/70 hover:bg-background",
+            })}
+          >
+            <Info size={16} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="font-normal">
+            All messages listed in this table are in the release channel and are
+            either currently live or have been live on Firefox at one time.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/ui/infoicon.tsx
+++ b/components/ui/infoicon.tsx
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export function InfoButton() {
+export function InfoIcon( infoObject: any ) {
   return (
     <TooltipProvider>
       <Tooltip>
@@ -19,17 +19,15 @@ export function InfoButton() {
             className={buttonVariants({
               variant: "secondary",
               size: "sm",
-              className: "bg-background p-1 hover:text-primary/70 hover:bg-background",
+              className:
+                "bg-background p-1 hover:text-primary/70 hover:bg-background",
             })}
           >
-            <Info size={16} />
+            <Info size={infoObject.iconSize} />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p className="font-normal">
-            All messages listed in this table are in the release channel and are
-            either currently live or have been live on Firefox at one time.
-          </p>
+          <p className="font-normal">{infoObject.content}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/components/ui/infoicon.tsx
+++ b/components/ui/infoicon.tsx
@@ -10,7 +10,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export function InfoIcon( infoObject: any ) {
+type InfoProps = {
+  iconSize: number
+  content: string
+}
+
+export function InfoIcon( {iconSize, content}: InfoProps ) {
   return (
     <TooltipProvider>
       <Tooltip>
@@ -20,14 +25,14 @@ export function InfoIcon( infoObject: any ) {
               variant: "secondary",
               size: "sm",
               className:
-                "bg-background p-1 hover:text-primary/70 hover:bg-background",
+                "bg-background p-2 hover:text-primary/70 hover:bg-background",
             })}
           >
-            <Info size={infoObject.iconSize} />
+            <Info size={iconSize} />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p className="font-normal">{infoObject.content}</p>
+          <p className="font-normal">{content}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/components/ui/infoicon.tsx
+++ b/components/ui/infoicon.tsx
@@ -11,11 +11,11 @@ import {
 } from "@/components/ui/tooltip";
 
 type InfoProps = {
-  iconSize: number
-  content: string
-}
+  iconSize: number;
+  content: string;
+};
 
-export function InfoIcon( {iconSize, content}: InfoProps ) {
+export function InfoIcon({ iconSize, content }: InfoProps) {
   return (
     <TooltipProvider>
       <Tooltip>


### PR DESCRIPTION
**Bug 1891083**

Changes made:
- Updated the titles for both tables in Skylight
- Created an `InfoIcon` component using the existing tooltip components to be able to show a description of the main table when hovering over the info icon (see screenshot below)

<img width="956" alt="Screenshot 2024-05-09 at 1 40 59 PM" src="https://github.com/mozilla/skylight/assets/60327675/2f2e83ec-9c8e-4fad-a893-0d5a339b8496">
