### PR TITLE
Bug 1890870 - Make branches collapsible for experiment tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Friday, May 17th, 2024
+
+### Added
+
+* Experiment rows now have toggle buttons that will expand/collapse all its branches
+* The experiments table header now has a toggle button that will expand/collapse all of the experiments at once
+
 ## Wednesday, April 24th, 2024
 
 ### Added

--- a/__tests__/app/message-table.test.tsx
+++ b/__tests__/app/message-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MessageTable } from "@/app/message-table";
 import { experimentColumns, RecipeOrBranchInfo } from "@/app/columns";
 import { ExperimentFakes } from "@/__tests__/ExperimentFakes.mjs";
@@ -6,19 +6,84 @@ import { NimbusRecipe } from "@/lib/nimbusRecipe";
 
 describe("MessageTable", () => {
   describe("ExperimentColumns", () => {
-    it("renders the branch description and slug", () => {
+    it("renders the branch description and slug on expanded branch rows", () => {
       const rawRecipe = ExperimentFakes.recipe("test-recipe");
       const nimbusRecipe = new NimbusRecipe(rawRecipe);
       const messageTableData: RecipeOrBranchInfo[] =
-        nimbusRecipe.getRecipeOrBranchInfos();
+        [nimbusRecipe.getRecipeInfo()];
+      render(
+        <MessageTable columns={experimentColumns} data={messageTableData} />
+      );
+
+      const toggleButton = screen.getByTestId("toggleBranchRowsButton")
+      fireEvent.click(toggleButton)
+
+      expect(screen.getByRole("table")).toBeInTheDocument();
+      expect(screen.getByText("test description")).toBeInTheDocument();
+      expect(screen.getByText("treatment")).toBeInTheDocument();
+    });
+
+    it("expands all experiment rows when clicking the header toggle button", () => {
+      const rawRecipe1 = ExperimentFakes.recipe("test-recipe-1");
+      const rawRecipe2 = ExperimentFakes.recipe("test-recipe-2");
+      const nimbusRecipe1 = new NimbusRecipe(rawRecipe1);
+      const nimbusRecipe2 = new NimbusRecipe(rawRecipe2);
+      const messageTableData: RecipeOrBranchInfo[] = [
+        nimbusRecipe1.getRecipeInfo(),
+        nimbusRecipe2.getRecipeInfo(),
+      ];
+      render(
+        <MessageTable columns={experimentColumns} data={messageTableData} />
+      );
+
+      const toggleButton = screen.getByTestId("toggleAllRowsButton");
+      fireEvent.click(toggleButton);
+
+      expect(screen.getAllByText("control description").length).toBe(2);
+      expect(screen.getAllByText("control").length).toBe(2);
+      expect(screen.getAllByText("test description").length).toBe(2);
+      expect(screen.getAllByText("treatment").length).toBe(2);
+    });
+
+    it("renders collapsed branch rows at start up", () => {
+      const rawRecipe = ExperimentFakes.recipe("test-recipe");
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
+      const messageTableData: RecipeOrBranchInfo[] = [
+        nimbusRecipe.getRecipeInfo(),
+      ];
 
       render(
         <MessageTable columns={experimentColumns} data={messageTableData} />
       );
 
-      expect(screen.getByRole("table")).toBeInTheDocument();
-      expect(screen.getByText("test description")).toBeInTheDocument();
-      expect(screen.getByText("treatment")).toBeInTheDocument();
+      const controlBranchDescription = screen.queryByText(
+        "control description"
+      );
+      expect(controlBranchDescription).not.toBeInTheDocument();
+      const treatmentBranchDescription = screen.queryByText("test description");
+      expect(treatmentBranchDescription).not.toBeInTheDocument();
+    });
+
+    it("collapses branch rows when clicking the experiment toggle button again after expanding the rows", () => {
+      const rawRecipe = ExperimentFakes.recipe("test-recipe");
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
+      const messageTableData: RecipeOrBranchInfo[] = [
+        nimbusRecipe.getRecipeInfo(),
+      ];
+      render(
+        <MessageTable columns={experimentColumns} data={messageTableData} />
+      );
+
+      const toggleButton = screen.getByTestId("toggleBranchRowsButton");
+      fireEvent.click(toggleButton);
+      fireEvent.click(toggleButton);
+
+      const controlBranchDescription = screen.queryByText(
+        "control description"
+      );
+      expect(controlBranchDescription).not.toBeInTheDocument();
+      const treatmentBranchDescription = screen.queryByText("test description");
+      expect(treatmentBranchDescription).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -78,6 +78,7 @@ describe('NimbusRecipe', () => {
         userFacingName: "Test Recipe",
       });
       const nimbusRecipe = new NimbusRecipe(rawRecipe)
+      const branches = nimbusRecipe.getBranchInfos()
 
       const recipeInfo = nimbusRecipe.getRecipeInfo()
 
@@ -93,7 +94,8 @@ describe('NimbusRecipe', () => {
         metrics: 'some metrics',
         experimenterLink: `https://experimenter.services.mozilla.com/nimbus/test-recipe`,
         userFacingName: rawRecipe.userFacingName,
-        nimbusExperiment: rawRecipe
+        nimbusExperiment: rawRecipe,
+        branches: branches
       });
     })
   })

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -160,6 +160,7 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
           {...{
             onClick: table.getToggleAllRowsExpandedHandler(),
           }}
+          data-testid="toggleAllRowsButton"
         >
           {table.getIsAllRowsExpanded() ? (
             <ChevronUp className="mr-2" size={18} />
@@ -180,6 +181,7 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
                     onClick: props.row.getToggleExpandedHandler(),
                     style: { cursor: 'pointer' },
                   }}
+                  data-testid="toggleBranchRowsButton"
                 >
                   {props.row.getIsExpanded() ? (
                     <ChevronUp className="mr-2" size={18} />

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -4,7 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { NimbusRecipe } from "@/lib/nimbusRecipe";
 import { PreviewLinkButton } from "@/components/ui/previewlinkbutton";
-import { Copy } from "lucide-react";
+import { ChevronUp, ChevronDown, Copy } from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import {
   Tooltip,
@@ -67,6 +67,7 @@ export type RecipeInfo = {
   userFacingName?: string
   nimbusExperiment: NimbusExperiment
   isBranch?: boolean
+  branches: BranchInfo[]
 } | []
 
 export type BranchInfo = {
@@ -153,11 +154,45 @@ export const fxmsMessageColumns: ColumnDef<FxMSMessageInfo>[] = [
 export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
   {
     accessorKey: "dates",
-    header: "Dates",
+    header: ({ table }) => (
+      <div className="flex flex-row items-center">
+        <button
+          {...{
+            onClick: table.getToggleAllRowsExpandedHandler(),
+          }}
+        >
+          {table.getIsAllRowsExpanded() ? (
+            <ChevronUp className="mr-2" size={18} />
+          ) : (
+            <ChevronDown className="mr-2" size={18} />
+          )}
+        </button>
+        Dates 
+      </div>
+    ),
     cell: (props: any) => {
       return (
-        <PrettyDateRange startDate={props.row.original.startDate}
-          endDate={props.row.original.endDate} />
+        <div className="flex flex-row items-center">
+          <div>
+              {props.row.getCanExpand() ? (
+                <button
+                  {...{
+                    onClick: props.row.getToggleExpandedHandler(),
+                    style: { cursor: 'pointer' },
+                  }}
+                >
+                  {props.row.getIsExpanded() ? (
+                    <ChevronUp className="mr-2" size={18} />
+                  ) : (
+                    <ChevronDown className="mr-2" size={18} />
+                  )}
+                </button>
+              ) : null}
+            </div>
+            <PrettyDateRange startDate={props.row.original.startDate}
+              endDate={props.row.original.endDate} />
+        </div>
+        
       );
     }
   },
@@ -167,14 +202,14 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <>
+          <div>
             <div className="font-semibold text-sm">
               {props.row.original.userFacingName || props.row.original.id}
             </div>
             <div className="font-mono text-3xs">
               {props.row.original.id}
             </div>
-          </>
+          </div>
         );
       }
 

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -202,14 +202,14 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <div>
+          <>
             <div className="font-semibold text-sm">
               {props.row.original.userFacingName || props.row.original.id}
             </div>
             <div className="font-mono text-3xs">
               {props.row.original.id}
             </div>
-          </div>
+          </>
         );
       }
 

--- a/app/message-table.tsx
+++ b/app/message-table.tsx
@@ -4,7 +4,9 @@ import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   useReactTable,
+  ExpandedState
 } from "@tanstack/react-table"
 
 import {
@@ -17,6 +19,7 @@ import {
 } from "@/components/ui/table"
 
 import { BranchInfo } from "./columns.tsx"
+import { useState } from "react"
 
 interface MessageTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -27,10 +30,17 @@ export function MessageTable<TData, TValue>({
   columns,
   data,
 }: MessageTableProps<TData, TValue>) {
+  const [expanded, setExpanded] = useState<ExpandedState>({})
   const table = useReactTable({
     data,
     columns,
+    state: {
+      expanded,
+    },
+    onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
+    getSubRows: (originalRow: any) => originalRow.branches,
+    getExpandedRowModel: getExpandedRowModel(),
   })
 
   function getRowSpanForCell(cell : any) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,8 +85,7 @@ export default async function Dashboard() {
   // get in format useable by MessageTable
   const experimentAndBranchInfo : RecipeOrBranchInfo[] =
     msgExpRecipeCollection.recipes.map(
-      // XXX needing the `.flat(1)` here is a bug
-      (recipe : NimbusRecipe) => recipe.getRecipeOrBranchInfos()).flat(1)
+      (recipe : NimbusRecipe) => recipe.getRecipeInfo())
 
 
   const totalExperiments = msgExpRecipeCollection.recipes.length

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,12 +101,8 @@ export default async function Dashboard() {
   const totalExperiments = msgExpRecipeCollection.recipes.length
 
   const msgRolloutInfo: RecipeOrBranchInfo[] =
-    msgRolloutRecipeCollection.recipes
-      .map(
-        // XXX needing the `.flat(1)` here is a bug
-        (recipe: NimbusRecipe) => recipe.getRecipeOrBranchInfos()
-      )
-      .flat(1);
+    msgRolloutRecipeCollection.recipes.map(
+      (recipe : NimbusRecipe) => recipe.getRecipeInfo())
 
   const totalRolloutExperiments = msgRolloutRecipeCollection.recipes.length;
 

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -203,7 +203,8 @@ null,
       metrics: 'some metrics',
       experimenterLink: `https://experimenter.services.mozilla.com/nimbus/${this._rawRecipe.slug}`,
       userFacingName: this._rawRecipe.userFacingName,
-      nimbusExperiment: this._rawRecipe
+      nimbusExperiment: this._rawRecipe,
+      branches: this.getBranchInfos()
     };
   }
 


### PR DESCRIPTION
**Bug 1890870**

Changes made:
- Used the [Tanstack Table Expanding API](https://tanstack.com/table/v8/docs/guide/expanding) to make branch rows collapsible
- The chevron arrows by each experiment collapses/expands the branches to the specific experiment
- The chevron arrow at the header of the table collapses/expands all of the experiments all at once
- Currently, only toggling the chevron buttons (not the whole row) will collapse/expand