### PR TITLE
Bug 1891126 - Make experiment and branch names hyperlink to recipe

### DIFF
--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -286,4 +286,21 @@ describe('NimbusRecipe', () => {
       expect(result).toBe(false)
     })
   })
+
+  describe('getBranchRecipeLink', () => {
+    it('returns a link to the branch recipe in experimenter', () => {
+      const rawRecipe = ExperimentFakes.recipe("test-recipe", {
+        slug: "goat shearing`test"
+      });
+      const nimbusRecipe = new NimbusRecipe(rawRecipe)
+
+      // having a weird char in the branch slug helps test that the code
+      // is calling encodeURIComponent
+      const branchSlug : string = "treatment`a"
+
+      const result = nimbusRecipe.getBranchRecipeLink(branchSlug)
+
+      expect(result).toBe(`https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(rawRecipe.slug)}/summary#${branchSlug}`)
+    })
+  })
 })

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -265,42 +265,46 @@ describe('NimbusRecipe', () => {
     })
   })
 
-  describe('isExpRecipe', () => {
-    it('returns true if the recipe is an experiment recipe not in rollout', () => {
+  describe("isExpRecipe", () => {
+    it("returns true if the recipe is an experiment recipe not in rollout", () => {
       const rawRecipe = ExperimentFakes.recipe("test-recipe");
-      const nimbusRecipe = new NimbusRecipe(rawRecipe)
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
 
-      const result = nimbusRecipe.isExpRecipe()
+      const result = nimbusRecipe.isExpRecipe();
 
-      expect(result).toBe(true)
-    })
+      expect(result).toBe(true);
+    });
 
-    it('returns false if the recipe is a message rollout', () => {
+    it("returns false if the recipe is a message rollout", () => {
       const rawRecipe = ExperimentFakes.recipe("test-recipe", {
-        isRollout: true
+        isRollout: true,
       });
-      const nimbusRecipe = new NimbusRecipe(rawRecipe)
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
 
-      const result = nimbusRecipe.isExpRecipe()
+      const result = nimbusRecipe.isExpRecipe();
 
-      expect(result).toBe(false)
-    })
-  })
+      expect(result).toBe(false);
+    });
+  });
 
-  describe('getBranchRecipeLink', () => {
-    it('returns a link to the branch recipe in experimenter', () => {
+  describe("getBranchRecipeLink", () => {
+    it("returns a link to the branch recipe in experimenter", () => {
       const rawRecipe = ExperimentFakes.recipe("test-recipe", {
-        slug: "goat shearing`test"
+        slug: "goat shearing`test",
       });
-      const nimbusRecipe = new NimbusRecipe(rawRecipe)
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
 
       // having a weird char in the branch slug helps test that the code
       // is calling encodeURIComponent
-      const branchSlug : string = "treatment`a"
+      const branchSlug: string = "treatment`a";
 
-      const result = nimbusRecipe.getBranchRecipeLink(branchSlug)
+      const result = nimbusRecipe.getBranchRecipeLink(branchSlug);
 
-      expect(result).toBe(`https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(rawRecipe.slug)}/summary#${branchSlug}`)
-    })
-  })
+      expect(result).toBe(
+        `https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(
+          rawRecipe.slug
+        )}/summary#${branchSlug}`
+      );
+    });
+  });
 })

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -168,12 +168,15 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
       if (props.row.original.userFacingName) {
         return (
           <>
-            <a href={props.row.original.experimenterLink} className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline" target="_blank" rel="noreferrer">
+            <a
+              href={props.row.original.experimenterLink}
+              className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
+              target="_blank"
+              rel="noreferrer"
+            >
               {props.row.original.userFacingName || props.row.original.id}
             </a>
-            <div className="font-mono text-3xs">
-              {props.row.original.id}
-            </div>
+            <div className="font-mono text-3xs">{props.row.original.id}</div>
           </>
         );
       }
@@ -181,15 +184,17 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
       const recipe = new NimbusRecipe(props.row.original.nimbusExperiment)
 
       return (
-          <div className="ps-6">
-            <a href={recipe.getBranchRecipeLink(props.row.original.slug)} className="text-xs text-primary visited:text-inherit hover:text-blue-800 no-underline" target="_blank" rel="noreferrer">
-              {props.row.original.description || props.row.original.id}
-            </a>
-            <p className="font-mono text-3xs">
-              {props.row.original.slug}
-            </p>
-          </div>
-          
+        <div className="ps-6">
+          <a
+            href={recipe.getBranchRecipeLink(props.row.original.slug)}
+            className="text-xs text-primary visited:text-inherit hover:text-blue-800 no-underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {props.row.original.description || props.row.original.id}
+          </a>
+          <p className="font-mono text-3xs">{props.row.original.slug}</p>
+        </div>
       );
     }
   },

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -168,9 +168,9 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
       if (props.row.original.userFacingName) {
         return (
           <>
-            <div className="font-semibold text-sm">
+            <a href={props.row.original.experimenterLink} className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline" target="_blank" rel="noreferrer">
               {props.row.original.userFacingName || props.row.original.id}
-            </div>
+            </a>
             <div className="font-mono text-3xs">
               {props.row.original.id}
             </div>
@@ -178,11 +178,13 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
         );
       }
 
+      const recipe = new NimbusRecipe(props.row.original.nimbusExperiment)
+
       return (
           <div className="ps-6">
-            <p className="text-xs">
+            <a href={recipe.getBranchRecipeLink(props.row.original.slug)} className="text-xs text-primary visited:text-inherit hover:text-blue-800 no-underline" target="_blank" rel="noreferrer">
               {props.row.original.description || props.row.original.id}
-            </p>
+            </a>
             <p className="font-mono text-3xs">
               {props.row.original.slug}
             </p>

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -29,6 +29,7 @@ type NimbusRecipeType = {
   getBranchScreenshotsLink(branchSlug: string) : string
   usesMessagingFeatures() : boolean
   isExpRecipe(): boolean
+  getBranchRecipeLink(branchSlug: string): string
 }
 
 export class NimbusRecipe implements NimbusRecipeType {
@@ -258,5 +259,12 @@ null,
    */
   isExpRecipe() {
     return !this._rawRecipe.isRollout
+  }
+
+  /** 
+   * @returns a link to recipe section of the Experimenter page for that branch.
+   */
+  getBranchRecipeLink(branchSlug: string): string {
+    return `https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(this._rawRecipe.slug)}/summary#${branchSlug}`
   }
 }

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -265,6 +265,8 @@ null,
    * @returns a link to recipe section of the Experimenter page for that branch.
    */
   getBranchRecipeLink(branchSlug: string): string {
-    return `https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(this._rawRecipe.slug)}/summary#${branchSlug}`
+    return `https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(
+      this._rawRecipe.slug
+    )}/summary#${branchSlug}`;
   }
 }


### PR DESCRIPTION
**Bug 1891126**

Changes made:
- Linked experiment names and branch descriptions to their recipes and respective navigation anchors
- Currently, the styling is implemented to not include the typical underlining and visited color changes of hyperlinks because I thought it would lessen the clutter, but it can be easily changed back if needed
- NOTE: I kept the existing experiment offsite link in the right-most column since that button stands out more but can be convinced to have them removed now that the experiment names are hyperlinked