### PR TITLE
Bug 1897771 - First iteration of menu button for helpful messaging system info links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Tuesday, May 21st, 2024
+
+### Added
+
+* Added a Messaging Info navigation menu to include links to key messaging resources
+
 ## Friday, May 17th, 2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 * Added a Messaging Info navigation menu to include links to key messaging resources
+* Added a Help/Feedback button linking to the #skylight-messaging-system slack channel
 
 ## Tuesday, May 21st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
-## Tuesday, May 21st, 2024
+## Friday, May 24th, 2024
 
-<<<<<<< bug-1897771
 ### Added
 
 * Added a Messaging Info navigation menu to include links to key messaging resources
-=======
+
+## Tuesday, May 21st, 2024
+
 ### Changed
 
 * Updated experiment names and branch descriptions to hyperlink to their recipe on Experimenter
 * Removed Experimenter link from the right-most column
->>>>>>> main
 
 ## Friday, May 17th, 2024
 

--- a/__tests__/components/ui/menubutton.test.tsx
+++ b/__tests__/components/ui/menubutton.test.tsx
@@ -6,6 +6,7 @@ describe("MenuButton", () => {
     render(<MenuButton />);
     
     const menuButton = screen.getByText("Messaging Info");
+    
     expect(menuButton).toBeInTheDocument();
   });
 

--- a/__tests__/components/ui/menubutton.test.tsx
+++ b/__tests__/components/ui/menubutton.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MenuButton } from "@/components/ui/menubutton.tsx";
+
+describe("MenuButton", () => {
+  it("renders a MenuButton button", () => {
+    render(<MenuButton />);
+    
+    const menuButton = screen.getByText("Messaging Info");
+    expect(menuButton).toBeInTheDocument();
+  });
+
+  it("displays menu content on focus", () => {
+    render(<MenuButton/>);
+    const menuButton = screen.getByText("Messaging Info");
+
+    fireEvent.focus(menuButton)
+
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  })
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,10 +122,6 @@ export default async function Dashboard() {
           <li>
             To make the preview URLs work: load <code>about:config</code> in Firefox, and set <code>browser.newtabpage.activity-stream.asrouter.devtoolsEnabled</code> to <code>true</code>; <b>a Firefox 126 build from March 29 or newer</b> is required.
           </li>
-
-          <li>
-          Feedback of all kinds accepted in <Link href="https://mozilla.slack.com/archives/C05N15KHCLC">#skylight-messaging-system</Link>
-          </li>
         </ul>
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,27 @@
+import * as React from "react"
+
 import { types } from "@mozilla/nimbus-shared";
 import { BranchInfo, RecipeOrBranchInfo, experimentColumns, FxMSMessageInfo, fxmsMessageColumns } from "./columns";
 import { getDashboard, getDisplayNameForTemplate, getTemplateFromMessage, _isAboutWelcomeTemplate, getPreviewLink } from "../lib/messageUtils.ts";
 import { NimbusRecipeCollection } from "../lib/nimbusRecipeCollection"
 import { _substituteLocalizations } from "../lib/experimentUtils.ts";
 
+import { cn } from "@/lib/utils"
 import { InfoIcon } from "@/components/ui/infoicon.tsx";
 import { NimbusRecipe } from "../lib/nimbusRecipe.ts"
 import { MessageTable } from "./message-table";
 import Link from "next/link";
+import { Apple, Menu } from "lucide-react";
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from "@/components/ui/navigation-menu"
 
 function getASRouterLocalColumnFromJSON(messageDef: any) : FxMSMessageInfo {
   let fxmsMsgInfo : FxMSMessageInfo = {
@@ -83,6 +97,32 @@ async function getMsgRolloutCollection(
   return msgRolloutRecipeCollection;
 }
 
+const ListItem = React.forwardRef<
+  React.ElementRef<"a">,
+  React.ComponentPropsWithoutRef<"a">
+>(({ className, title, children, ...props }, ref) => {
+  return (
+    <li>
+      <NavigationMenuLink asChild>
+        <a
+          ref={ref}
+          className={cn(
+            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+            className
+          )}
+          {...props}
+        >
+          <div className="text-sm font-medium leading-none">{title}</div>
+          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+            {children}
+          </p>
+        </a>
+      </NavigationMenuLink>
+    </li>
+  )
+})
+ListItem.displayName = "ListItem"
+
 export default async function Dashboard() {
   const recipeCollection = new NimbusRecipeCollection()
   await recipeCollection.fetchRecipes()
@@ -109,9 +149,49 @@ export default async function Dashboard() {
   return (
     <div>
       <div>
-        <h4 className="scroll-m-20 text-3xl font-semibold text-center py-4">
-          Skylight
-        </h4>
+        <div className="flex justify-between mx-20 py-8">
+          <h4 className="scroll-m-20 text-3xl font-semibold">
+            Skylight
+          </h4>
+          <NavigationMenu>
+            <NavigationMenuList>
+              <NavigationMenuItem>
+                <NavigationMenuTrigger><Menu /></NavigationMenuTrigger>
+                <NavigationMenuContent>
+                <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+                  <li className="row-span-3">
+                    <NavigationMenuLink asChild>
+                      <a
+                        className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
+                        href="/"
+                      >
+                        <Apple className="h-6 w-6" />
+                        <div className="mb-2 mt-4 text-lg font-medium">
+                          shadcn/ui
+                        </div>
+                        <p className="text-sm leading-tight text-muted-foreground">
+                          Beautifully designed components that you can copy and
+                          paste into your apps. Accessible. Customizable. Open
+                          Source.
+                        </p>
+                      </a>
+                    </NavigationMenuLink>
+                  </li>
+                  <ListItem href="/docs" title="Introduction">
+                    Re-usable components built using Radix UI and Tailwind CSS.
+                  </ListItem>
+                  <ListItem href="/docs/installation" title="Installation">
+                    How to install dependencies and structure your app.
+                  </ListItem>
+                  <ListItem href="/docs/primitives/typography" title="Typography">
+                    Styles for headings, paragraphs, lists...etc
+                  </ListItem>
+                </ul>
+                </NavigationMenuContent>
+              </NavigationMenuItem>
+            </NavigationMenuList>
+          </NavigationMenu>
+        </div>
 
         <ul className='list-[circle] mx-20 text-sm'>
           <li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,10 +126,6 @@ export default async function Dashboard() {
           <li>
           Feedback of all kinds accepted in <Link href="https://mozilla.slack.com/archives/C05N15KHCLC">#skylight-messaging-system</Link>
           </li>
-
-          <li>
-            <b>(*)</b> Production Messages - Release Channel is currently a partial list. Nimbus rollouts, remote-settings messages, and a small number of others are planned.
-          </li>
         </ul>
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,15 @@
-import * as React from "react"
-
 import { types } from "@mozilla/nimbus-shared";
 import { BranchInfo, RecipeOrBranchInfo, experimentColumns, FxMSMessageInfo, fxmsMessageColumns } from "./columns";
 import { getDashboard, getDisplayNameForTemplate, getTemplateFromMessage, _isAboutWelcomeTemplate, getPreviewLink } from "../lib/messageUtils.ts";
 import { NimbusRecipeCollection } from "../lib/nimbusRecipeCollection"
 import { _substituteLocalizations } from "../lib/experimentUtils.ts";
 
-import { cn } from "@/lib/utils"
 import { InfoIcon } from "@/components/ui/infoicon.tsx";
 import { NimbusRecipe } from "../lib/nimbusRecipe.ts"
 import { MessageTable } from "./message-table";
 import Link from "next/link";
-import { Apple, Menu } from "lucide-react";
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuIndicator,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-  NavigationMenuViewport,
-} from "@/components/ui/navigation-menu"
+
+import { MenuButton } from "@/components/ui/menubutton.tsx";
 
 function getASRouterLocalColumnFromJSON(messageDef: any) : FxMSMessageInfo {
   let fxmsMsgInfo : FxMSMessageInfo = {
@@ -97,32 +85,6 @@ async function getMsgRolloutCollection(
   return msgRolloutRecipeCollection;
 }
 
-const ListItem = React.forwardRef<
-  React.ElementRef<"a">,
-  React.ComponentPropsWithoutRef<"a">
->(({ className, title, children, ...props }, ref) => {
-  return (
-    <li>
-      <NavigationMenuLink asChild>
-        <a
-          ref={ref}
-          className={cn(
-            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
-            className
-          )}
-          {...props}
-        >
-          <div className="text-sm font-medium leading-none">{title}</div>
-          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-            {children}
-          </p>
-        </a>
-      </NavigationMenuLink>
-    </li>
-  )
-})
-ListItem.displayName = "ListItem"
-
 export default async function Dashboard() {
   const recipeCollection = new NimbusRecipeCollection()
   await recipeCollection.fetchRecipes()
@@ -153,44 +115,7 @@ export default async function Dashboard() {
           <h4 className="scroll-m-20 text-3xl font-semibold">
             Skylight
           </h4>
-          <NavigationMenu>
-            <NavigationMenuList>
-              <NavigationMenuItem>
-                <NavigationMenuTrigger><Menu /></NavigationMenuTrigger>
-                <NavigationMenuContent>
-                <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
-                  <li className="row-span-3">
-                    <NavigationMenuLink asChild>
-                      <a
-                        className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
-                        href="/"
-                      >
-                        <Apple className="h-6 w-6" />
-                        <div className="mb-2 mt-4 text-lg font-medium">
-                          shadcn/ui
-                        </div>
-                        <p className="text-sm leading-tight text-muted-foreground">
-                          Beautifully designed components that you can copy and
-                          paste into your apps. Accessible. Customizable. Open
-                          Source.
-                        </p>
-                      </a>
-                    </NavigationMenuLink>
-                  </li>
-                  <ListItem href="/docs" title="Introduction">
-                    Re-usable components built using Radix UI and Tailwind CSS.
-                  </ListItem>
-                  <ListItem href="/docs/installation" title="Installation">
-                    How to install dependencies and structure your app.
-                  </ListItem>
-                  <ListItem href="/docs/primitives/typography" title="Typography">
-                    Styles for headings, paragraphs, lists...etc
-                  </ListItem>
-                </ul>
-                </NavigationMenuContent>
-              </NavigationMenuItem>
-            </NavigationMenuList>
-          </NavigationMenu>
+          <MenuButton />
         </div>
 
         <ul className='list-[circle] mx-20 text-sm'>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,7 +114,6 @@ export default async function Dashboard() {
   return (
     <div>
       <div>
-<<<<<<< bug-1897771
         <div className="flex justify-between mx-20 py-8">
           <h4 className="scroll-m-20 text-3xl font-semibold">
             Skylight
@@ -122,11 +121,6 @@ export default async function Dashboard() {
           <MenuButton />
         </div>
 
-=======
-        <h4 className="scroll-m-20 text-3xl font-semibold text-center py-4">
-          Skylight
-        </h4>
->>>>>>> main
         <ul className='list-[circle] mx-20 text-sm'>
           <li>
             To make the preview URLs work: load <code>about:config</code> in Firefox, and set <code>browser.newtabpage.activity-stream.asrouter.devtoolsEnabled</code> to <code>true</code>; <b>a Firefox 126 build from March 29 or newer</b> is required.

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -9,8 +9,9 @@ import {
   NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import { Menu } from "lucide-react";
+import { Menu, Slack } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ListItem = React.forwardRef<
@@ -44,35 +45,38 @@ export function MenuButton() {
     <NavigationMenu>
       <NavigationMenuList>
         <NavigationMenuItem>
+          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+            <a
+              className="no-underline flex text-primary hover:bg-accent hover:text-accent-foreground visited:text-inherit"
+              href="https://mozilla.slack.com/archives/C05N15KHCLC"
+            >
+              <Slack size={20} className="mr-1" />
+              Help/Feedback
+            </a>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
           <NavigationMenuTrigger>
-            Messaging Info <Menu className="ml-2" />
+            <Menu className="mr-1" /> Messaging Info
           </NavigationMenuTrigger>
           <NavigationMenuContent>
             <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <ListItem
                 href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team"
-                title="General Info & Getting Help"
-              >
-                General information about the OMC team and how to request for
-                in-product messaging.
-              </ListItem>
+                title="OMC General Info"
+              />
               <ListItem
                 href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
                 title="Messaging Surfaces"
-              >
-                Overview of various messaging surfaces available in Firefox
-                Desktop.
-              </ListItem>
+              />
               <ListItem
                 href="https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/"
-                title="Detailed Technical Documentation"
-              >
-                Documentation for Firefox Home (New Tab).
-              </ListItem>
+                title="New Tab Technical Documentation"
+              />
               <ListItem
                 href="https://mozilla.cloud.looker.com/dashboards/1461?Normalized+Channel=release"
                 title="Looker Top 20 Messages Dashboard"
-              ></ListItem>
+              />
             </ul>
           </NavigationMenuContent>
         </NavigationMenuItem>

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -5,12 +5,10 @@ import * as React from "react";
 import {
   NavigationMenu,
   NavigationMenuContent,
-  NavigationMenuIndicator,
   NavigationMenuItem,
   NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
-  NavigationMenuViewport,
 } from "@/components/ui/navigation-menu";
 import { Apple, Menu } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -47,7 +45,7 @@ export function MenuButton() {
       <NavigationMenuList>
         <NavigationMenuItem>
           <NavigationMenuTrigger>
-            <Menu />
+            Messaging Info <Menu className="ml-2" />
           </NavigationMenuTrigger>
           <NavigationMenuContent>
             <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
@@ -55,13 +53,15 @@ export function MenuButton() {
                 href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team"
                 title="General Info & Getting Help"
               >
-                General information about the OMC team and how to request for in-product messaging.
+                General information about the OMC team and how to request for
+                in-product messaging.
               </ListItem>
               <ListItem
                 href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
                 title="Messaging Surfaces"
               >
-                Overview of various messaging surfaces available in Firefox Desktop.
+                Overview of various messaging surfaces available in Firefox
+                Desktop.
               </ListItem>
               <ListItem
                 href="https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/"
@@ -72,8 +72,7 @@ export function MenuButton() {
               <ListItem
                 href="https://mozilla.cloud.looker.com/dashboards/1461?Normalized+Channel=release"
                 title="Looker Top 20 Messages Dashboard"
-              >
-              </ListItem>
+              ></ListItem>
             </ul>
           </NavigationMenuContent>
         </NavigationMenuItem>

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -10,7 +10,7 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger,
 } from "@/components/ui/navigation-menu";
-import { Apple, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ListItem = React.forwardRef<

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from "@/components/ui/navigation-menu";
+import { Apple, Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ListItem = React.forwardRef<
+  React.ElementRef<"a">,
+  React.ComponentPropsWithoutRef<"a">
+>(({ className, title, children, ...props }, ref) => {
+  return (
+    <li>
+      <NavigationMenuLink asChild>
+        <a
+          ref={ref}
+          className={cn(
+            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground visited:text-inherit focus:bg-accent focus:text-accent-foreground",
+            className
+          )}
+          {...props}
+        >
+          <div className="text-sm font-medium leading-none">{title}</div>
+          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+            {children}
+          </p>
+        </a>
+      </NavigationMenuLink>
+    </li>
+  );
+});
+ListItem.displayName = "ListItem";
+
+export function MenuButton() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>
+            <Menu />
+          </NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+              <ListItem
+                href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team"
+                title="General Info & Getting Help"
+              >
+                General information about the OMC team and how to request for in-product messaging.
+              </ListItem>
+              <ListItem
+                href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
+                title="Messaging Surfaces"
+              >
+                Overview of various messaging surfaces available in Firefox Desktop.
+              </ListItem>
+              <ListItem
+                href="https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/"
+                title="Detailed Technical Documentation"
+              >
+                Documentation for Firefox Home (New Tab).
+              </ListItem>
+              <ListItem
+                href="https://mozilla.cloud.looker.com/dashboards/1461?Normalized+Channel=release"
+                title="Looker Top 20 Messages Dashboard"
+              >
+              </ListItem>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+}

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -11,7 +11,7 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import { Menu, Slack } from "lucide-react";
+import { Menu, Hash } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ListItem = React.forwardRef<
@@ -50,7 +50,7 @@ export function MenuButton() {
               className="no-underline flex text-primary hover:bg-accent hover:text-accent-foreground visited:text-inherit"
               href="https://mozilla.slack.com/archives/C05N15KHCLC"
             >
-              <Slack size={20} className="mr-1" />
+              <Hash className="mr-1" />
               Help/Feedback
             </a>
           </NavigationMenuLink>
@@ -63,15 +63,15 @@ export function MenuButton() {
             <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <ListItem
                 href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team"
-                title="OMC General Info"
+                title="OMC Team Info"
               />
               <ListItem
                 href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
                 title="Messaging Surfaces"
               />
               <ListItem
-                href="https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/"
-                title="New Tab Technical Documentation"
+                href="https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/index.html"
+                title="Technical Documentation"
               />
               <ListItem
                 href="https://mozilla.cloud.looker.com/dashboards/1461?Normalized+Channel=release"

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import * as React from "react"
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
+import { cva } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const NavigationMenu = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <NavigationMenuViewport />
+  </NavigationMenuPrimitive.Root>
+))
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
+
+const NavigationMenuList = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    ref={ref}
+    className={cn(
+      "group flex flex-1 list-none items-center justify-center space-x-1",
+      className
+    )}
+    {...props}
+  />
+))
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+)
+
+const NavigationMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Trigger
+    ref={ref}
+    className={cn(navigationMenuTriggerStyle(), "group", className)}
+    {...props}
+  >
+    {children}{" "}
+    {/* <ChevronDown
+      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+      aria-hidden="true"
+    /> */}
+  </NavigationMenuPrimitive.Trigger>
+))
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName
+
+const NavigationMenuContent = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Content
+    ref={ref}
+    className={cn(
+      "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto ",
+      className
+    )}
+    {...props}
+  />
+))
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName
+
+const NavigationMenuLink = NavigationMenuPrimitive.Link
+
+const NavigationMenuViewport = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <div className={cn("absolute right-0 top-full flex justify-center")}>
+    <NavigationMenuPrimitive.Viewport
+      className={cn(
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  </div>
+))
+NavigationMenuViewport.displayName =
+  NavigationMenuPrimitive.Viewport.displayName
+
+const NavigationMenuIndicator = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Indicator
+    ref={ref}
+    className={cn(
+      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
+      className
+    )}
+    {...props}
+  >
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+  </NavigationMenuPrimitive.Indicator>
+))
+NavigationMenuIndicator.displayName =
+  NavigationMenuPrimitive.Indicator.displayName
+
+export {
+  navigationMenuTriggerStyle,
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+}

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -55,10 +55,6 @@ const NavigationMenuTrigger = React.forwardRef<
     {...props}
   >
     {children}{" "}
-    {/* <ChevronDown
-      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
-      aria-hidden="true"
-    /> */}
   </NavigationMenuPrimitive.Trigger>
 ))
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@mozilla/nimbus-shared": "^2.5.2",
+        "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-table": "^8.17.3",
@@ -1703,6 +1704,32 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
@@ -1724,6 +1751,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
       "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -1778,6 +1822,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.1.4.tgz",
+      "integrity": "sha512-Cc+seCS3PmWmjI51ufGG7zp1cAAIRqHVw7C9LOA2TZ+R4hG6rDvHcTqIsEEFLmZO3zNVH72jOOE7kKNy8W+RtA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1993,6 +2073,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
       "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@mozilla/nimbus-shared": "^2.5.2",
+    "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-table": "^8.17.3",


### PR DESCRIPTION
[**Bug 1897771**](https://bugzilla.mozilla.org/show_bug.cgi?id=1897771)

Changes made:
- Created a `menubutton.tsx` component using the [Navigation Menu shadcn component](https://ui.shadcn.com/docs/components/navigation-menu) to the top-right of Skylight which includes the following links:
  - [General Info & Getting Help](https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team)
  - [Messaging Surfaces](https://experimenter.info/messaging/desktop-messaging-surfaces/)
  - [Detailed Technical Documentation](https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/)
  - [Looker Top 20 Messages Dashboard](https://mozilla.cloud.looker.com/dashboards/1461?Normalized+Channel=release)