### PR TITLE
Remove the logout button since logout is not implemented

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -154,11 +154,6 @@ export default async function Dashboard() {
 
       <div className="space-y-5 container mx-auto py-10">
         <MessageTable columns={experimentColumns} data={experimentAndBranchInfo} />
-        {isAuthEnabled ? (
-          <div>
-            <a className="text-s" href="/api/auth/logout">Logout</a>
-          </div>
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
We never fully implemented the logout route in out Auth0, so the logout button doesn't do anything. This just removes it.