### PR TITLE
Bug 1899375 - Add default expanded option for tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Thursday, June 13th, 2024
+
+### Added
+
+* Added an option to make experiment tables default to being fully expanded or collapsed
+
 ## Monday, May 27th, 2024
 
 ### Added

--- a/app/message-table.tsx
+++ b/app/message-table.tsx
@@ -24,7 +24,7 @@ import { useState } from "react"
 interface MessageTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
-  defaultExpaned?: boolean
+  defaultExpanded?: boolean
 }
 
 export function MessageTable<TData, TValue>({
@@ -32,6 +32,7 @@ export function MessageTable<TData, TValue>({
   data,
   defaultExpanded
 }: MessageTableProps<TData, TValue>) {
+  // Tables will start collapsed if defaultExpanded is undefined
   const [expanded, setExpanded] = useState<ExpandedState>(defaultExpanded || {})
   const table = useReactTable({
     data,

--- a/app/message-table.tsx
+++ b/app/message-table.tsx
@@ -24,13 +24,15 @@ import { useState } from "react"
 interface MessageTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
+  defaultExpaned?: boolean
 }
 
 export function MessageTable<TData, TValue>({
   columns,
   data,
+  defaultExpanded
 }: MessageTableProps<TData, TValue>) {
-  const [expanded, setExpanded] = useState<ExpandedState>({})
+  const [expanded, setExpanded] = useState<ExpandedState>(defaultExpanded || {})
   const table = useReactTable({
     data,
     columns,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -142,7 +142,7 @@ export default async function Dashboard() {
         Total: {totalRolloutExperiments}
       </h5>
       <div className="container mx-auto py-10">
-        <MessageTable columns={experimentColumns} data={msgRolloutInfo} defaultExpaned={false}/>
+        <MessageTable columns={experimentColumns} data={msgRolloutInfo} defaultExpanded={false}/>
       </div>
 
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
@@ -153,7 +153,7 @@ export default async function Dashboard() {
       </h5>
 
       <div className="space-y-5 container mx-auto py-10">
-        <MessageTable columns={experimentColumns} data={experimentAndBranchInfo} defaultExpaned={true} />
+        <MessageTable columns={experimentColumns} data={experimentAndBranchInfo} defaultExpanded={true} />
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -142,7 +142,7 @@ export default async function Dashboard() {
         Total: {totalRolloutExperiments}
       </h5>
       <div className="container mx-auto py-10">
-        <MessageTable columns={experimentColumns} data={msgRolloutInfo} />
+        <MessageTable columns={experimentColumns} data={msgRolloutInfo} defaultExpaned={false}/>
       </div>
 
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
@@ -153,7 +153,7 @@ export default async function Dashboard() {
       </h5>
 
       <div className="space-y-5 container mx-auto py-10">
-        <MessageTable columns={experimentColumns} data={experimentAndBranchInfo} />
+        <MessageTable columns={experimentColumns} data={experimentAndBranchInfo} defaultExpaned={true} />
       </div>
     </div>
   );


### PR DESCRIPTION
[**Bug 1899375**](https://bugzilla.mozilla.org/show_bug.cgi?id=1899375)

Changes made:
- Add an option to make experiment tables start fully expanded/collapsed 
- Made experiment table (not rollouts) default expanded

