### PR TITLE
Bug 1902424 - Fix weird feature callout dashboard lossage

### DIFF
--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -105,7 +105,9 @@ export class NimbusRecipe implements NimbusRecipeType {
 
       case 'feature_callout':
         // XXX should iterate over all screens
-        branchInfo.id = feature.value.content.screens[0].id
+        // XXX some branches have incorrect ":treatment-a" attached to the end
+        // of the id that needs to be removed (see https://bugzilla.mozilla.org/show_bug.cgi?id=1902424)
+        branchInfo.id = feature.value.content.screens[0].id.split(":")[0]
         break
 
       case 'infobar':

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -105,13 +105,15 @@ export class NimbusRecipe implements NimbusRecipeType {
 
       case 'feature_callout':
         // XXX should iterate over all screens
+        //
         // NOTE: Some branches have incorrect ":treatment-a" attached to the end
-        // of the id, which needs to be removed to display the correct dashboard
-        // link (see https://bugzilla.mozilla.org/show_bug.cgi?id=1902424).
-        // The problem was in the experiment JSON object, so splitting the 
-        // ":treatment-a" here was the quickest solution. Some long-term 
-        // solutions we can consider include linting, implementing JSON schemas 
-        // or eliminating the error via a GUI message creation.
+        // of the id, which is breaking the Looker dashboard links
+        // (see https://bugzilla.mozilla.org/show_bug.cgi?id=1902424).
+        // The problem was in the recipe JSON in Experimenter, likely a user error
+        // during experiment creation that involved some cloning or copy/paste. 
+        //
+        // XXX consider pulling branch ids from somewhere else that is validated
+        // by Experimenter, to avoid similar user errors in branch ids.
         branchInfo.id = feature.value.content.screens[0].id.split(":")[0]
         break
 

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -105,8 +105,13 @@ export class NimbusRecipe implements NimbusRecipeType {
 
       case 'feature_callout':
         // XXX should iterate over all screens
-        // XXX some branches have incorrect ":treatment-a" attached to the end
-        // of the id that needs to be removed (see https://bugzilla.mozilla.org/show_bug.cgi?id=1902424)
+        // NOTE: Some branches have incorrect ":treatment-a" attached to the end
+        // of the id, which needs to be removed to display the correct dashboard
+        // link (see https://bugzilla.mozilla.org/show_bug.cgi?id=1902424).
+        // The problem was in the experiment JSON object, so splitting the 
+        // ":treatment-a" here was the quickest solution. Some long-term 
+        // solutions we can consider include linting, implementing JSON schemas 
+        // or eliminating the error via a GUI message creation.
         branchInfo.id = feature.value.content.screens[0].id.split(":")[0]
         break
 


### PR DESCRIPTION
[**Bug 1902424**](https://bugzilla.mozilla.org/show_bug.cgi?id=1902424)

Changes made:
- I added a fix for the weird branch ids for the following experiments: [Discovery of Search SAP Early Day EN](https://experimenter.services.mozilla.com/nimbus/discovery-of-search-sap-early-day-en/summary#treatment-b) and [Discovery of Search SAP Existing EN](https://experimenter.services.mozilla.com/nimbus/discovery-of-search-sap-existing-en/summary#treatment-b)
    - Those branch ids in the jsons had `:treatment-a` at the end despite it being treatment-b branches