### PR TITLE
Bug 1901036 - Display more accurate CTR percents including infobar messages

### DIFF
--- a/__tests__/app/message-table.test.tsx
+++ b/__tests__/app/message-table.test.tsx
@@ -177,9 +177,9 @@ describe("MessageTable", () => {
 
       const toggleButton = screen.getByTestId("toggleAllRowsButton");
       fireEvent.click(toggleButton);
-      const ctrMetrics = screen.getByText("12.3% CTR");
+      const ctrMetrics = screen.getByText("12.35% CTR");
 
-      expect(recipeInfos[0].branches[0].ctrPercent).toBe(12.3);
+      expect(recipeInfos[0].branches[0].ctrPercent).toBe(12.35);
       expect(recipeInfos[0].branches[0].ctrDashboardLink).toBeDefined();
       expect(ctrMetrics).toBeInTheDocument();
     });
@@ -234,13 +234,13 @@ describe("MessageTable", () => {
         surface: "test surface",
         segment: "test segment",
         metrics: "test metrics",
-        ctrPercent: 12.3,
+        ctrPercent: 12.35,
         ctrPercentChange: 2,
         ctrDashboardLink: "test link"
       };
       render(<MessageTable columns={fxmsMessageColumns} data={[fakeMsgInfo]} />);
 
-      const ctrMetrics = screen.getByText("12.3% CTR");
+      const ctrMetrics = screen.getByText("12.35% CTR");
 
       expect(ctrMetrics).toBeInTheDocument();
     });

--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -28,6 +28,6 @@ describe("Looker", () => {
 
     const ctrPercent = await looker.getCTRPercent(id, template);
 
-    expect(ctrPercent).toEqual(12.3);
+    expect(ctrPercent).toEqual(12.35);
   });
 });

--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -9,13 +9,15 @@ jest.mock("../../lib/sdk");
 
 describe("Looker", () => {
   it("should return the first dashboard element", async () => {
-    const element = await looker.getAWDashboardElement0();
+    const template = "test_template";
+    const element = await looker.getAWDashboardElement0(template);
 
     expect(element).toEqual(fakeDashboardElements[0]);
   });
 
   it("should return the query results", async () => {
-    const queryResult = await looker.runEventCountQuery(fakeFilters);
+    const template = "test_template";
+    const queryResult = await looker.runQueryForTemplate(template, fakeFilters);
 
     expect(queryResult).toEqual(fakeQueryResult);
   });

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -1,4 +1,4 @@
-import { getDashboard, _isAboutWelcomeTemplate, toBinary } from '@/lib/messageUtils'
+import { getDashboard, _isAboutWelcomeTemplate, toBinary, getDashboardIdForTemplate } from '@/lib/messageUtils'
 
 describe('isAboutWelcomeTemplate', () => {
   it('returns true if a feature_callout', () => {
@@ -64,18 +64,20 @@ describe('getDashboard', () => {
     const channel = "release"
     const experiment = "experiment:test"
     const branchSlug = "treatment:a"
+    const dashboardId = getDashboardIdForTemplate(template)
 
     const result = getDashboard(template, msgId, channel, experiment, branchSlug)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1775?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`
     expect(result).toEqual(expectedLink)
   })
 
   it('returns a correct featureCallout dashboard link', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
+    const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId)
     expect(result).toEqual(expectedLink)
@@ -87,8 +89,9 @@ describe('getDashboard', () => {
     const msgId = "1:23" // weird chars to test URI encoding
     const experiment = "experiment:test"
     const branchSlug = "treatment:a"
+    const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
 
     const result = getDashboard(template, msgId, undefined, experiment, branchSlug)
     expect(result).toEqual(expectedLink)

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -67,7 +67,7 @@ describe('getDashboard', () => {
 
     const result = getDashboard(template, msgId, channel, experiment, branchSlug)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1682?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30+days&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1775?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`
     expect(result).toEqual(expectedLink)
   })
 

--- a/__tests__/lib/nimbusRecipeCollection.test.ts
+++ b/__tests__/lib/nimbusRecipeCollection.test.ts
@@ -39,8 +39,8 @@ describe('NimbusRecipeCollection', () => {
       const recipeInfos =
         (await nimbusRecipeCollection.getExperimentAndBranchInfos()) as RecipeInfo[];
 
-      expect(recipeInfos[0].branches[0].ctrPercent).toBe(12.3);
-      expect(recipeInfos[0].branches[1].ctrPercent).toBe(12.3);
+      expect(recipeInfos[0].branches[0].ctrPercent).toBe(12.35);
+      expect(recipeInfos[0].branches[1].ctrPercent).toBe(12.35);
     });
   });
 })

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -91,8 +91,6 @@ export type BranchInfo = {
 export type RecipeOrBranchInfo = RecipeInfo | BranchInfo;
 
 /**
- * XXX fix https://bugzilla.mozilla.org/show_bug.cgi?id=1901036 to remove the 
- * infobar template condition
  * @returns an OffsiteLink linking to the Looker dashboard link if it exists,
  * labelled with either the CTR percent or "Dashboard"
  */
@@ -101,7 +99,7 @@ function showCTRMetrics(
   ctrDashboardLink?: string,
   ctrPercent?: number
 ) {
-  if (ctrDashboardLink && ctrPercent !== undefined && template !== "infobar") {
+  if (ctrDashboardLink && ctrPercent !== undefined) {
     return OffsiteLink(ctrDashboardLink, ctrPercent + "% CTR");
   } else if (ctrDashboardLink) {
     return OffsiteLink(ctrDashboardLink, "Dashboard");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,14 +27,16 @@ async function getASRouterLocalColumnFromJSON(messageDef: any) : Promise<FxMSMes
     previewLink: getPreviewLink(maybeCreateWelcomePreview(messageDef)),
   };
 
+  const channel = "release";
+
   if (isLookerEnabled) {
-    const ctrPercent = await getCTRPercent(messageDef.id, fxmsMsgInfo.template)
+    const ctrPercent = await getCTRPercent(messageDef.id, fxmsMsgInfo.template, channel)
     if (ctrPercent) {
       fxmsMsgInfo.ctrPercent = ctrPercent
     }
   }
   
-  fxmsMsgInfo.ctrDashboardLink = getDashboard(messageDef.template, messageDef.id, "release")
+  fxmsMsgInfo.ctrDashboardLink = getDashboard(messageDef.template, messageDef.id, channel)
 
   // dashboard link -> dashboard id -> query id -> query -> ctr_percent_from_lastish_day
 

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -26,17 +26,17 @@ export async function runEventCountQuery(filters: any, template: string): Promis
   if (template === "infobar") {
     newQueryBody.filters = Object.assign(
       {
-        'messaging_system.submission_date': '1 day ago for 1 day'
+        "messaging_system.submission_date": "1 day ago for 1 day",
       },
       filters
-    )
+    );
   } else {
     newQueryBody.filters = Object.assign(
       {
-        'event_counts.submission_timestamp_date': '2 days'
+        "event_counts.submission_timestamp_date": "2 days",
       },
       filters
-    )
+    );
   }
 
   const newQuery = await SDK.ok(SDK.create_query(newQueryBody));
@@ -58,26 +58,37 @@ export async function runEventCountQuery(filters: any, template: string): Promis
  * @returns a CTR percent value for a message if the Looker query results are
  * defined
  */
-export async function getCTRPercent(id: string, template: string, channel?: string, experiment?: string, branch?: string): Promise<number|undefined> {
+export async function getCTRPercent(
+  id: string,
+  template: string,
+  channel?: string,
+  experiment?: string,
+  branch?: string
+): Promise<number | undefined> {
   let queryResult;
   if (template === "infobar") {
     queryResult = await runEventCountQuery(
-      { 'messaging_system.metrics__text2__messaging_system_message_id': id,
-        'messaging_system.normalized_channel': channel,
-        'messaging_system.metrics__string__messaging_system_ping_type': template },
+      {
+        "messaging_system.metrics__text2__messaging_system_message_id": id,
+        "messaging_system.normalized_channel": channel,
+        "messaging_system.metrics__string__messaging_system_ping_type":
+          template,
+      },
       template
-    )
+    );
   } else {
     queryResult = await runEventCountQuery(
-      { 'event_counts.message_id':  '%' + id + '%',
-        'event_counts.normalized_channel': channel,
-        'onboarding_v1__experiments.experiment': experiment,
-        'onboarding_v1__experiments.branch': branch },
+      {
+        "event_counts.message_id": "%" + id + "%",
+        "event_counts.normalized_channel": channel,
+        "onboarding_v1__experiments.experiment": experiment,
+        "onboarding_v1__experiments.branch": branch,
+      },
       template
-    )
+    );
   }
 
   if (queryResult.length > 0) {
-    return Number(Number(queryResult[0].primary_rate * 100).toFixed(1))
+    return Number(Number(queryResult[0].primary_rate * 100).toFixed(1));
   }
 }

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -63,6 +63,9 @@ export async function getCTRPercent(
   experiment?: string,
   branch?: string
 ): Promise<number | undefined> {
+  // XXX the filters are currently defined to match the filters in getDashboard.
+  // It would be more ideal to consider a different approach when definining
+  // those filters to sync up the data in both places.
   let queryResult;
   if (template === "infobar") {
     queryResult = await runQueryForTemplate(template, {
@@ -82,6 +85,8 @@ export async function getCTRPercent(
   }
 
   if (queryResult.length > 0) {
-    return Number(Number(queryResult[0].primary_rate * 100).toFixed(1));
+    // CTR percents will have 2 decimal places since this is what is expected
+    // from Experimenter analyses.
+    return Number(Number(queryResult[0].primary_rate * 100).toFixed(2));
   }
 }

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -1,8 +1,11 @@
 import { IDashboardElement, IWriteQuery } from "@looker/sdk"
 import { SDK } from "./sdk";
 
-export async function getAWDashboardElement0(): Promise<IDashboardElement> {
-  const dashboardId = "1471";
+export async function getAWDashboardElement0(template: string): Promise<IDashboardElement> {
+  let dashboardId = "1677";
+  if (template === "infobar") {
+    dashboardId = "1775";
+  }
 
   // XXX switch this out for the more performant dashboard_element (see 
   // https://mozilla.cloud.looker.com/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Dashboard/dashboard_element
@@ -11,8 +14,8 @@ export async function getAWDashboardElement0(): Promise<IDashboardElement> {
   return elements[0];
 }
 
-export async function runEventCountQuery(filters: any): Promise<any>{
-  const element0 = await getAWDashboardElement0()
+export async function runEventCountQuery(filters: any, template: string): Promise<any>{
+  const element0 = await getAWDashboardElement0(template)
   const origQuery = element0.query as IWriteQuery
 
   // take the query from the original dashboard
@@ -20,12 +23,21 @@ export async function runEventCountQuery(filters: any): Promise<any>{
   delete newQueryBody.client_id // must be unique per-query
 
   // override the filters
-  newQueryBody.filters = Object.assign(
-    {
-      'event_counts.submission_timestamp_date': '2 days'
-    },
-    filters
-  )
+  if (template === "infobar") {
+    newQueryBody.filters = Object.assign(
+      {
+        'messaging_system.submission_date': '1 day ago for 1 day'
+      },
+      filters
+    )
+  } else {
+    newQueryBody.filters = Object.assign(
+      {
+        'event_counts.submission_timestamp_date': '2 days'
+      },
+      filters
+    )
+  }
 
   const newQuery = await SDK.ok(SDK.create_query(newQueryBody));
   const result = await SDK.ok(SDK.run_query({
@@ -40,17 +52,32 @@ export async function runEventCountQuery(filters: any): Promise<any>{
  * @param id the events_count.message_id required for running the looker 
  * query to retrieve CTR metrics
  * @param template the message template
+ * @param channel the normalized channel
+ * @param experiment the experiment slug
+ * @param branch the branch slug
  * @returns a CTR percent value for a message if the Looker query results are
  * defined
  */
-export async function getCTRPercent(id: string, template?: string): Promise<number|undefined> {
-  const queryResult = await runEventCountQuery(
-    { 'event_counts.message_id':  '%' + id + '%' }
-  )
+export async function getCTRPercent(id: string, template: string, channel?: string, experiment?: string, branch?: string): Promise<number|undefined> {
+  let queryResult;
+  if (template === "infobar") {
+    queryResult = await runEventCountQuery(
+      { 'messaging_system.metrics__text2__messaging_system_message_id': id,
+        'messaging_system.normalized_channel': channel,
+        'messaging_system.metrics__string__messaging_system_ping_type': template },
+      template
+    )
+  } else {
+    queryResult = await runEventCountQuery(
+      { 'event_counts.message_id':  '%' + id + '%',
+        'event_counts.normalized_channel': channel,
+        'onboarding_v1__experiments.experiment': experiment,
+        'onboarding_v1__experiments.branch': branch },
+      template
+    )
+  }
 
-  // XXX fix https://bugzilla.mozilla.org/show_bug.cgi?id=1901036 to remove the 
-  // infobar template condition
-  if (queryResult.length > 0 && template !== 'infobar') {
+  if (queryResult.length > 0) {
     return Number(Number(queryResult[0].primary_rate * 100).toFixed(1))
   }
 }

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -56,13 +56,14 @@ export function getDashboard(
   const encodedChannel = channel ? (encodeURIComponent(channel)) : "";
   const encodedExperiment = experiment ? (encodeURIComponent(experiment)) : "";
   const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
+  const dashboardId = getDashboardIdForTemplate(template);
 
   if (_isAboutWelcomeTemplate(template)) {
-    return `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/1775?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
   }
 
   return undefined;
@@ -109,6 +110,7 @@ export function getPreviewLink(message: any): string {
 }
 
 /**
+ * XXX consider moving this function inside looker.ts
  * @returns the Looker dashboard ID for a given message template
  */
 export function getDashboardIdForTemplate(template: string) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -62,7 +62,7 @@ export function getDashboard(
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/1682?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+days&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/1775?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
   }
 
   return undefined;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -107,3 +107,14 @@ export function getPreviewLink(message: any): string {
 
   return previewLink;
 }
+
+/**
+ * @returns the Looker dashboard ID for a given message template
+ */
+export function getDashboardIdForTemplate(template: string) {
+  if (template === "infobar") {
+    return "1775";
+  } else {
+    return "1677";
+  }
+}

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -21,7 +21,10 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
         // Looker being case sensitive
         const ctrPercent = await getCTRPercent(
           branchInfo.id.toUpperCase(),
-          branchInfo.template
+          branchInfo.template!,
+          undefined,
+          branchInfo.nimbusExperiment.slug,
+          branchInfo.slug
         );
         if (ctrPercent) {
           branchInfo.ctrPercent = ctrPercent;


### PR DESCRIPTION
[**Bug 1901036**](https://bugzilla.mozilla.org/show_bug.cgi?id=1901036)

Changes made:
- Duplicated the [infobar Looker dashboard](https://mozilla.cloud.looker.com/dashboards/1775?Messaging+System+Ping+Type=infobar&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=INFOBAR_LAUNCH_ON_LOGIN_FINAL&Normalized+Channel=release&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=&Experiment+Branch=) and enabled infobar CTRs in Skylight
- I noticed the CTR percents displayed in Skylight didn't accurately reflect the CTR percents in the dashboards. So the looker API query filters have been updated to match the same filters in the dashboard links, which now makes the displayed CTR percents match the ones in the dashboards. 

Note: Looker needs to be enabled locally to test this patch