### PR TITLE
Bug 19093853 - Make rollouts table expanded by default

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,7 +167,7 @@ export default async function Dashboard() {
         Total: {totalRolloutExperiments}
       </h5>
       <div className="container mx-auto py-10">
-        <MessageTable columns={experimentColumns} data={msgRolloutInfo} defaultExpanded={false}/>
+        <MessageTable columns={experimentColumns} data={msgRolloutInfo} defaultExpanded={true}/>
       </div>
 
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">


### PR DESCRIPTION
[**Bug 1903853**](https://bugzilla.mozilla.org/show_bug.cgi?id=1903853)

Changes made:
- Made rollout messages table fully expanded by default as per UX feedback