### PR TITLE
Bug 1904388 - Constrain dashboard to the experiment length

### DIFF
--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -97,4 +97,16 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   });
 
+  it('returns a correct dashboard link with start and end dates', () => {
+    const template = "feature_callout"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const startDate = "2024-03-08"
+    const endDate = "2024-06-28"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2024-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+
+    const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
+    expect(result).toEqual(expectedLink)
+  })
+
 })

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -77,7 +77,7 @@ describe('getDashboard', () => {
     const msgId = "1:23" // weird chars to test URI encoding
     const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId)
     expect(result).toEqual(expectedLink)
@@ -91,7 +91,7 @@ describe('getDashboard', () => {
     const branchSlug = "treatment:a"
     const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
 
     const result = getDashboard(template, msgId, undefined, experiment, branchSlug)
     expect(result).toEqual(expectedLink)

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -97,7 +97,7 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   });
 
-  it('returns a correct dashboard link with start and end dates', () => {
+  it('returns a correct dashboard link with defined start and end dates', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
@@ -109,4 +109,14 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   })
 
+  it('returns a correct dashboard link with a defined start date', () => {
+    const template = "feature_callout"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const startDate = "2024-03-08"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+
+    const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, null)
+    expect(result).toEqual(expectedLink)
+  })
 })

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -97,13 +97,25 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   });
 
-  it('returns a correct dashboard link with defined start and end dates', () => {
+  it('returns a correct dashboard link with defined start and end dates where the end date is in the future', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
-    const endDate = "2024-06-28"
+    const endDate = "2025-06-28"
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2024-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+
+    const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
+    expect(result).toEqual(expectedLink)
+  })
+
+  it('returns a correct dashboard link with defined start and end dates where the end date is in the past', () => {
+    const template = "feature_callout"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const startDate = "2024-03-08"
+    const endDate = "2024-05-28"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
     expect(result).toEqual(expectedLink)

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -135,7 +135,7 @@ describe('NimbusRecipe', () => {
       // use deepEqual and check for the existence of object properties instead.
       expect(branchInfo).toEqual({
         product: 'Desktop',
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE,
@@ -162,7 +162,7 @@ describe('NimbusRecipe', () => {
       
       expect(branchInfo).toEqual({
         product: 'Desktop',
-        ctrDashboardLink: "https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a",
+        ctrDashboardLink: "https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a",
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE_NO_SCREENS,

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -58,14 +58,16 @@ export function getDashboard(
   const encodedChannel = channel ? (encodeURIComponent(channel)) : "";
   const encodedExperiment = experiment ? (encodeURIComponent(experiment)) : "";
   const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
+  const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
+  const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
   const dashboardId = getDashboardIdForTemplate(template);
 
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
   if (startDate && endDate && (new Date() < new Date(endDate))) {
-    encodedSubmissionDate = `${startDate}+to+${endDate}`;
+    encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;
   } else if (startDate) {
-    encodedSubmissionDate = `${startDate}+to+today`;
+    encodedSubmissionDate = `${encodedStartDate}+to+today`;
   }
 
   if (_isAboutWelcomeTemplate(template)) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -60,13 +60,10 @@ export function getDashboard(
   const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
   const dashboardId = getDashboardIdForTemplate(template);
 
-  const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
-  const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
-
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
-  if (encodedStartDate && encodedEndDate) {
-    encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;
+  if (startDate && endDate) {
+    encodedSubmissionDate = `${startDate}+to+${endDate}`;
   }
 
   if (_isAboutWelcomeTemplate(template)) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -64,6 +64,8 @@ export function getDashboard(
   let encodedSubmissionDate = "30+day+ago+for+30+day";
   if (startDate && endDate) {
     encodedSubmissionDate = `${startDate}+to+${endDate}`;
+  } else if (startDate) {
+    encodedSubmissionDate = `${startDate}+to+today`;
   }
 
   if (_isAboutWelcomeTemplate(template)) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -49,7 +49,9 @@ export function getDashboard(
   msgId: string,
   channel?: string,
   experiment?: string,
-  branchSlug?: string): string | undefined {
+  branchSlug?: string,
+  startDate?: string | null,
+  endDate?: string | null): string | undefined {
 
   const encodedMsgId = encodeURIComponent(msgId);
   const encodedTemplate = encodeURIComponent(template);
@@ -58,12 +60,20 @@ export function getDashboard(
   const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
   const dashboardId = getDashboardIdForTemplate(template);
 
+  const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
+  const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
+
+  let encodedSubmissionDate = "30+day+ago+for+30+day";
+  if (encodedStartDate && encodedEndDate) {
+    encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;
+  }
+
   if (_isAboutWelcomeTemplate(template)) {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=${encodedSubmissionDate}&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
   }
 
   return undefined;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -62,7 +62,7 @@ export function getDashboard(
 
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
-  if (startDate && endDate) {
+  if (startDate && endDate && (new Date() < new Date(endDate))) {
     encodedSubmissionDate = `${startDate}+to+${endDate}`;
   } else if (startDate) {
     encodedSubmissionDate = `${startDate}+to+today`;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -63,6 +63,7 @@ export function getDashboard(
   const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
   const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
 
+  // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
   if (encodedStartDate && encodedEndDate) {
     encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,6 +181,8 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
+    // We are using the proposed end date + 1 as the end date because the end
+    // date is not inclusive in Looker
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,
       branchInfo.id,
@@ -188,7 +190,12 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
       branchInfo.nimbusExperiment.slug,
       branch.slug,
       branchInfo.nimbusExperiment.startDate,
-      branchInfo.nimbusExperiment.endDate
+      getProposedEndDate(
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.proposedDuration
+          ? branchInfo.nimbusExperiment.proposedDuration + 1
+          : undefined
+      )
     );
     if (!feature.value.content) {
       console.log("v.content is null")

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,10 +181,9 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
-
+    const endDate = branchInfo.nimbusExperiment.endDate || getProposedEndDate(branchInfo.nimbusExperiment.startDate, branchInfo.nimbusExperiment.proposedDuration ? branchInfo.nimbusExperiment.proposedDuration + 1 : undefined) || null;
     branchInfo.ctrDashboardLink =
-      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug)
-
+      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug, branchInfo.nimbusExperiment.startDate, endDate)
     if (!feature.value.content) {
       console.log("v.content is null")
       // console.log("v= ", value)

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,15 +181,6 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
-    const endDate =
-      branchInfo.nimbusExperiment.endDate ||
-      getProposedEndDate(
-        branchInfo.nimbusExperiment.startDate,
-        branchInfo.nimbusExperiment.proposedDuration
-          ? branchInfo.nimbusExperiment.proposedDuration + 1
-          : undefined
-      ) ||
-      null;
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,
       branchInfo.id,
@@ -197,7 +188,7 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
       branchInfo.nimbusExperiment.slug,
       branch.slug,
       branchInfo.nimbusExperiment.startDate,
-      endDate
+      branchInfo.nimbusExperiment.endDate
     );
     if (!feature.value.content) {
       console.log("v.content is null")

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,9 +181,24 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
-    const endDate = branchInfo.nimbusExperiment.endDate || getProposedEndDate(branchInfo.nimbusExperiment.startDate, branchInfo.nimbusExperiment.proposedDuration ? branchInfo.nimbusExperiment.proposedDuration + 1 : undefined) || null;
-    branchInfo.ctrDashboardLink =
-      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug, branchInfo.nimbusExperiment.startDate, endDate)
+    const endDate =
+      branchInfo.nimbusExperiment.endDate ||
+      getProposedEndDate(
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.proposedDuration
+          ? branchInfo.nimbusExperiment.proposedDuration + 1
+          : undefined
+      ) ||
+      null;
+    branchInfo.ctrDashboardLink = getDashboard(
+      branch.template,
+      branchInfo.id,
+      undefined,
+      branchInfo.nimbusExperiment.slug,
+      branch.slug,
+      branchInfo.nimbusExperiment.startDate,
+      endDate
+    );
     if (!feature.value.content) {
       console.log("v.content is null")
       // console.log("v= ", value)

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -183,6 +183,12 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
     }
     // We are using the proposed end date + 1 as the end date because the end
     // date is not inclusive in Looker
+    const proposedEndDate = getProposedEndDate(
+      branchInfo.nimbusExperiment.startDate,
+      branchInfo.nimbusExperiment.proposedDuration
+        ? branchInfo.nimbusExperiment.proposedDuration + 1
+        : undefined
+    );
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,
       branchInfo.id,
@@ -190,12 +196,7 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
       branchInfo.nimbusExperiment.slug,
       branch.slug,
       branchInfo.nimbusExperiment.startDate,
-      getProposedEndDate(
-        branchInfo.nimbusExperiment.startDate,
-        branchInfo.nimbusExperiment.proposedDuration
-          ? branchInfo.nimbusExperiment.proposedDuration + 1
-          : undefined
-      )
+      proposedEndDate
     );
     if (!feature.value.content) {
       console.log("v.content is null")


### PR DESCRIPTION
[**Bug 1904388**](https://bugzilla.mozilla.org/show_bug.cgi?id=1904388)

Changes made:
- Constrained dashboard link to filter dates based on experiment `startDate` and `endDate`
- The dashboard are restricted for the following cases:
    - Live message dashboards show data from the last 30 days (as it already was)
    - Experiment dashboards show data from `startDate` to today (since the `endDate` properties are always null)