### PR TITLE
WIP: make inline CTR numbers cover the entire dashboard length

### DIFF
--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -102,8 +102,9 @@ describe('getDashboard', () => {
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
     const endDate = "2025-06-28"
+    const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08+to+2025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
     expect(result).toEqual(expectedLink)
@@ -114,8 +115,9 @@ describe('getDashboard', () => {
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
     const endDate = "2024-05-28"
+    const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
     expect(result).toEqual(expectedLink)
@@ -125,8 +127,9 @@ describe('getDashboard', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
+    const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, null)
     expect(result).toEqual(expectedLink)

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -97,4 +97,16 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   });
 
+  it('returns a correct dashboard link with start and end dates', () => {
+    const template = "feature_callout"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const startDate = "2024-03-08"
+    const endDate = "2024-06-28"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2024-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+
+    const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
+    expect(result).toEqual(expectedLink)
+  })
+
 })

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -77,7 +77,7 @@ describe('getDashboard', () => {
     const msgId = "1:23" // weird chars to test URI encoding
     const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId)
     expect(result).toEqual(expectedLink)
@@ -91,7 +91,7 @@ describe('getDashboard', () => {
     const branchSlug = "treatment:a"
     const dashboardId = getDashboardIdForTemplate(template)
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`
 
     const result = getDashboard(template, msgId, undefined, experiment, branchSlug)
     expect(result).toEqual(expectedLink)

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -97,7 +97,7 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   });
 
-  it('returns a correct dashboard link with start and end dates', () => {
+  it('returns a correct dashboard link with defined start and end dates', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
@@ -109,4 +109,14 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   })
 
+  it('returns a correct dashboard link with a defined start date', () => {
+    const template = "feature_callout"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const startDate = "2024-03-08"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+
+    const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, null)
+    expect(result).toEqual(expectedLink)
+  })
 })

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -97,13 +97,25 @@ describe('getDashboard', () => {
     expect(result).toEqual(expectedLink)
   });
 
-  it('returns a correct dashboard link with defined start and end dates', () => {
+  it('returns a correct dashboard link with defined start and end dates where the end date is in the future', () => {
     const template = "feature_callout"
     const msgId = "1:23" // weird chars to test URI encoding
     const startDate = "2024-03-08"
-    const endDate = "2024-06-28"
+    const endDate = "2025-06-28"
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2024-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+2025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
+
+    const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
+    expect(result).toEqual(expectedLink)
+  })
+
+  it('returns a correct dashboard link with defined start and end dates where the end date is in the past', () => {
+    const template = "feature_callout"
+    const msgId = "1:23" // weird chars to test URI encoding
+    const startDate = "2024-03-08"
+    const endDate = "2024-05-28"
+
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=2024-03-08+to+today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`
 
     const result = getDashboard(template, msgId, undefined, undefined, undefined, startDate, endDate)
     expect(result).toEqual(expectedLink)

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -135,7 +135,7 @@ describe('NimbusRecipe', () => {
       // use deepEqual and check for the existence of object properties instead.
       expect(branchInfo).toEqual({
         product: 'Desktop',
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE,
@@ -162,7 +162,7 @@ describe('NimbusRecipe', () => {
       
       expect(branchInfo).toEqual({
         product: 'Desktop',
-        ctrDashboardLink: "https://mozilla.cloud.looker.com/dashboards/1677?Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a",
+        ctrDashboardLink: "https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a",
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE_NO_SCREENS,

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -1,6 +1,7 @@
 import { NimbusRecipe } from '@/lib/nimbusRecipe'
 import { ExperimentFakes } from '@/__tests__/ExperimentFakes.mjs'
 import { BranchInfo } from "@/app/columns.jsx"
+import { getDashboardIdForTemplate } from '@/lib/messageUtils'
 
 //XXX We're passing this custom object for about:welcome, since ExperimentFakes
 // doesn't quite give us what we want in that case. We probably want to tweak
@@ -129,13 +130,14 @@ describe('NimbusRecipe', () => {
       const branch = AW_RECIPE.branches[1]
 
       const branchInfo = nimbusRecipe.getBranchInfo(branch)
+      const dashboardId = getDashboardIdForTemplate("aboutwelcome")
 
       // XXX getBranchInfo is actually going to return a previewLink, which
       // makes this test kind of brittle. We could refactor this to no longer
       // use deepEqual and check for the existence of object properties instead.
       expect(branchInfo).toEqual({
         product: 'Desktop',
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE,
@@ -159,10 +161,11 @@ describe('NimbusRecipe', () => {
       const branch = AW_RECIPE_NO_SCREENS.branches[1]
 
       const branchInfo = nimbusRecipe.getBranchInfo(branch)
+      const dashboardId = getDashboardIdForTemplate("aboutwelcome")
       
       expect(branchInfo).toEqual({
         product: 'Desktop',
-        ctrDashboardLink: "https://mozilla.cloud.looker.com/dashboards/1677?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a",
+        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30+day+ago+for+30+day&Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE_NO_SCREENS,

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -99,7 +99,8 @@ function showCTRMetrics(
   ctrDashboardLink?: string,
   ctrPercent?: number
 ) {
-  if (ctrDashboardLink && ctrPercent !== undefined) {
+  // XXX remove infobar condition in https://bugzilla.mozilla.org/show_bug.cgi?id=1905155
+  if (ctrDashboardLink && ctrPercent !== undefined && template !== "infobar") {
     return OffsiteLink(ctrDashboardLink, ctrPercent + "% CTR");
   } else if (ctrDashboardLink) {
     return OffsiteLink(ctrDashboardLink, "Dashboard");

--- a/lib/__mocks__/sdk.ts
+++ b/lib/__mocks__/sdk.ts
@@ -20,12 +20,19 @@ export const fakeFilters = { 'event_counts.message_id':  '%test_query_0%' }
 export const fakeQuery = {
     id: "test_query"
 }
-export const fakeQueryResult = [{
-    "event_counts.submission_timestamp_date": "2024-06-04",
-    primary_rate: 0.123456789,
-    other_rate: 0.987654321,
-    "event_counts.user_count": {},
-}];
+export const fakeQueryResult = [
+    {
+        "primary_rate": 0.123456789,
+        "event_counts.user_count": {
+            "action": {
+                " Impression": 12899,
+                " Primary": 1592,
+                "Other": 2588
+            }
+        }
+    }
+];
+  
 
 export function getLookerSDK(): any {
     return "mocked SDK"
@@ -33,6 +40,7 @@ export function getLookerSDK(): any {
 
 export const SDK = {
     dashboard_dashboard_elements: () => fakeDashboardElements,
+    search_dashboard_elements: () => fakeDashboardElements,
     create_query: () => fakeQuery,
     run_query: () => fakeQueryResult,
     ok: (apiMethod: any) => {

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -56,7 +56,7 @@ export async function runQueryForTemplate(template: string, filters: any, startD
     } else if (startDate) {
       submission_timestamp_date = `${startDate} to today`;
     }
-    
+
     newQueryBody.filters = Object.assign(
       {
         "event_counts.submission_timestamp_date": submission_timestamp_date,
@@ -81,6 +81,8 @@ export async function runQueryForTemplate(template: string, filters: any, startD
  * @param channel the normalized channel
  * @param experiment the experiment slug
  * @param branch the branch slug
+ * @param startDate the experiment start date
+ * @param endDate the experiment proposed end date
  * @returns a CTR percent value for a message if the Looker query results are
  * defined
  */

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -5,7 +5,7 @@ import { getDashboardIdForTemplate } from "./messageUtils";
 export async function getAWDashboardElement0(template: string): Promise<IDashboardElement> {
   const dashboardId = getDashboardIdForTemplate(template);
 
-  // XXX switch this out for the more performant dashboard_element (see
+  // XXX maybe switch this out for the more performant dashboard_element (see
   // https://mozilla.cloud.looker.com/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Dashboard/dashboard_element
   // for more info).
 
@@ -50,6 +50,7 @@ export async function runQueryForTemplate(template: string, filters: any, startD
     );
   } else {
     // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
+    // XXX refactor the date logic below into a separate function (see https://bugzilla.mozilla.org/show_bug.cgi?id=1905204)
     let submission_timestamp_date = "30 day ago for 30 day";
     if (startDate && endDate && (new Date() < new Date(endDate))) {
       submission_timestamp_date = `${startDate} to ${endDate}`;
@@ -115,7 +116,6 @@ export async function getCTRPercent(
       "onboarding_v1__experiments.experiment": experiment,
       "onboarding_v1__experiments.branch": branch,
     }, startDate, endDate);
-    console.log("queryResult: ", queryResult);
   }
 
   if (queryResult.length > 0) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -60,13 +60,10 @@ export function getDashboard(
   const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
   const dashboardId = getDashboardIdForTemplate(template);
 
-  const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
-  const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
-
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
-  if (encodedStartDate && encodedEndDate) {
-    encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;
+  if (startDate && endDate) {
+    encodedSubmissionDate = `${startDate}+to+${endDate}`;
   }
 
   if (_isAboutWelcomeTemplate(template)) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -63,6 +63,7 @@ export function getDashboard(
   const dashboardId = getDashboardIdForTemplate(template);
 
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
+  // XXX refactor the date logic below into a separate function (see https://bugzilla.mozilla.org/show_bug.cgi?id=1905204)
   let encodedSubmissionDate = "30+day+ago+for+30+day";
   if (startDate && endDate && (new Date() < new Date(endDate))) {
     encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -129,6 +129,6 @@ export function getDashboardIdForTemplate(template: string) {
   if (template === "infobar") {
     return "1775";
   } else {
-    return "1677";
+    return "1806";
   }
 }

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -64,6 +64,8 @@ export function getDashboard(
   let encodedSubmissionDate = "30+day+ago+for+30+day";
   if (startDate && endDate) {
     encodedSubmissionDate = `${startDate}+to+${endDate}`;
+  } else if (startDate) {
+    encodedSubmissionDate = `${startDate}+to+today`;
   }
 
   if (_isAboutWelcomeTemplate(template)) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -49,7 +49,9 @@ export function getDashboard(
   msgId: string,
   channel?: string,
   experiment?: string,
-  branchSlug?: string): string | undefined {
+  branchSlug?: string,
+  startDate?: string | null,
+  endDate?: string | null): string | undefined {
 
   const encodedMsgId = encodeURIComponent(msgId);
   const encodedTemplate = encodeURIComponent(template);
@@ -58,12 +60,20 @@ export function getDashboard(
   const encodedBranchSlug = branchSlug ? (encodeURIComponent(branchSlug)) : "";
   const dashboardId = getDashboardIdForTemplate(template);
 
+  const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
+  const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
+
+  let encodedSubmissionDate = "30+day+ago+for+30+day";
+  if (encodedStartDate && encodedEndDate) {
+    encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;
+  }
+
   if (_isAboutWelcomeTemplate(template)) {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=30+day+ago+for+30+day&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=${encodedSubmissionDate}&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
   }
 
   return undefined;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -62,7 +62,7 @@ export function getDashboard(
 
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
-  if (startDate && endDate) {
+  if (startDate && endDate && (new Date() < new Date(endDate))) {
     encodedSubmissionDate = `${startDate}+to+${endDate}`;
   } else if (startDate) {
     encodedSubmissionDate = `${startDate}+to+today`;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -63,6 +63,7 @@ export function getDashboard(
   const encodedStartDate = startDate ? (encodeURIComponent(startDate)) : "";
   const encodedEndDate = endDate ? (encodeURIComponent(endDate)) : "";
 
+  // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let encodedSubmissionDate = "30+day+ago+for+30+day";
   if (encodedStartDate && encodedEndDate) {
     encodedSubmissionDate = `${encodedStartDate}+to+${encodedEndDate}`;

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -198,7 +198,6 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
       branchInfo.nimbusExperiment.startDate,
       proposedEndDate
     );
-
     if (!feature.value.content) {
       console.log("v.content is null")
       // console.log("v= ", value)

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,6 +181,8 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
+    // We are using the proposed end date + 1 as the end date because the end
+    // date is not inclusive in Looker
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,
       branchInfo.id,
@@ -188,7 +190,12 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
       branchInfo.nimbusExperiment.slug,
       branch.slug,
       branchInfo.nimbusExperiment.startDate,
-      branchInfo.nimbusExperiment.endDate
+      getProposedEndDate(
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.proposedDuration
+          ? branchInfo.nimbusExperiment.proposedDuration + 1
+          : undefined
+      )
     );
     if (!feature.value.content) {
       console.log("v.content is null")

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,10 +181,9 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
-
+    const endDate = branchInfo.nimbusExperiment.endDate || getProposedEndDate(branchInfo.nimbusExperiment.startDate, branchInfo.nimbusExperiment.proposedDuration ? branchInfo.nimbusExperiment.proposedDuration + 1 : undefined) || null;
     branchInfo.ctrDashboardLink =
-      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug)
-
+      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug, branchInfo.nimbusExperiment.startDate, endDate)
     if (!feature.value.content) {
       console.log("v.content is null")
       // console.log("v= ", value)

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,8 +181,10 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
+    
     // We are using the proposed end date + 1 as the end date because the end
     // date is not inclusive in Looker
+    // XXX refactor proposedEndDate into a separate function (see https://bugzilla.mozilla.org/show_bug.cgi?id=1905204)
     const proposedEndDate = getProposedEndDate(
       branchInfo.nimbusExperiment.startDate,
       branchInfo.nimbusExperiment.proposedDuration

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,15 +181,6 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
-    const endDate =
-      branchInfo.nimbusExperiment.endDate ||
-      getProposedEndDate(
-        branchInfo.nimbusExperiment.startDate,
-        branchInfo.nimbusExperiment.proposedDuration
-          ? branchInfo.nimbusExperiment.proposedDuration + 1
-          : undefined
-      ) ||
-      null;
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,
       branchInfo.id,
@@ -197,7 +188,7 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
       branchInfo.nimbusExperiment.slug,
       branch.slug,
       branchInfo.nimbusExperiment.startDate,
-      endDate
+      branchInfo.nimbusExperiment.endDate
     );
     if (!feature.value.content) {
       console.log("v.content is null")

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -181,9 +181,24 @@ this._rawRecipe.localizations?.[Object.keys(this._rawRecipe.localizations)[0]])
         branchInfo.id = feature.value.messages[0].id
         break
     }
-    const endDate = branchInfo.nimbusExperiment.endDate || getProposedEndDate(branchInfo.nimbusExperiment.startDate, branchInfo.nimbusExperiment.proposedDuration ? branchInfo.nimbusExperiment.proposedDuration + 1 : undefined) || null;
-    branchInfo.ctrDashboardLink =
-      getDashboard(branch.template, branchInfo.id, undefined, branchInfo.nimbusExperiment.slug, branch.slug, branchInfo.nimbusExperiment.startDate, endDate)
+    const endDate =
+      branchInfo.nimbusExperiment.endDate ||
+      getProposedEndDate(
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.proposedDuration
+          ? branchInfo.nimbusExperiment.proposedDuration + 1
+          : undefined
+      ) ||
+      null;
+    branchInfo.ctrDashboardLink = getDashboard(
+      branch.template,
+      branchInfo.id,
+      undefined,
+      branchInfo.nimbusExperiment.slug,
+      branch.slug,
+      branchInfo.nimbusExperiment.startDate,
+      endDate
+    );
     if (!feature.value.content) {
       console.log("v.content is null")
       // console.log("v= ", value)

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -18,6 +18,9 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
   return await Promise.all(
     recipe.getBranchInfos().map(
       async (branchInfo: BranchInfo): Promise<BranchInfo> => {
+        // We are using the proposed end date + 1 as the end date because the end
+        // date is not inclusive in Looker
+        // XXX refactor proposedEndDate into a separate function (see https://bugzilla.mozilla.org/show_bug.cgi?id=1905204)
         const proposedEndDate = getProposedEndDate(
           branchInfo.nimbusExperiment.startDate,
           branchInfo.nimbusExperiment.proposedDuration

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -2,6 +2,7 @@ import { types } from "@mozilla/nimbus-shared"
 import { NimbusRecipe } from "../lib/nimbusRecipe"
 import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "@/app/columns"
 import { getCTRPercent } from "./looker"
+import { getProposedEndDate } from "./experimentUtils"
 
 type NimbusExperiment = types.experiments.NimbusExperiment
 
@@ -17,6 +18,12 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
   return await Promise.all(
     recipe.getBranchInfos().map(
       async (branchInfo: BranchInfo): Promise<BranchInfo> => {
+        const proposedEndDate = getProposedEndDate(
+          branchInfo.nimbusExperiment.startDate,
+          branchInfo.nimbusExperiment.proposedDuration
+            ? branchInfo.nimbusExperiment.proposedDuration + 1
+            : undefined
+        );
         // We are making all branch ids upper case to make up for
         // Looker being case sensitive
         const ctrPercent = await getCTRPercent(
@@ -24,7 +31,9 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
           branchInfo.template!,
           undefined,
           branchInfo.nimbusExperiment.slug,
-          branchInfo.slug
+          branchInfo.slug,
+          branchInfo.nimbusExperiment.startDate,
+          proposedEndDate
         );
         if (ctrPercent) {
           branchInfo.ctrPercent = ctrPercent;


### PR DESCRIPTION
This branch is based against the current version of https://github.com/mozilla/skylight/pull/266 and will need to be merged or rebased once that lands.

So far: 

* Looker:
  * Created an element for the about:welcome dashboard that shows CTR and impressions for the dashboard duration
  * Forked the about:welcome dashboard
  * Inserted the CTR/impression element into the forked dashboard
  * Removed the "Other" line
  * Clarified and corrected labels
* This branch
  * Updated to use the new dashboard fork
  * Added code to get the inline CTR info data from the new element
    * This works for dashboards in the release section because they happen to be the 30-day length

Soo...

I think the main things left to do are:
* Make this work with the experiment dates, analogous to those changes in #266.

* handle the infobar dashboard (although since there are no infobar experiments currently, we could potentially push this off to another bug)
** Fork the infobar dashboard and update the code to point to it
** make a similar CTR/impressions element and add it to the forked dashboard
** Update the code to pull its data from the new summary element and handle 

One possibility would be to write the tests in another bug immediately after, just to get this landed.

Because there seems to be a lot of room for error in copy-pasting and then adjusting all the experiment date-handling code in various places, it might be faster to switch to TDD now. Figuring out the right tests to write is not obvious to me at this moment, but maybe after I've slept on it.
