### PR TITLE
Bug 1905155 - make inline CTR numbers cover the entire Infobar dashboard length

### DIFF
--- a/__tests__/lib/lookerUtils.test.ts
+++ b/__tests__/lib/lookerUtils.test.ts
@@ -1,6 +1,6 @@
 import { getExperimentLookerDashboardDate, getLookerSubmissionTimestampDateFilter } from "@/lib/lookerUtils";
 
-describe("getExperimentDashboardDates", () => {
+describe("getExperimentLookerDashboardDate", () => {
     it("returns the correct end date when startDate and proposedDuration are defined", () => {
       const startDate = "2024-06-28";
       const proposedDuration = 10;
@@ -27,7 +27,7 @@ describe("getExperimentDashboardDates", () => {
     });
 });
 
-describe("getSubmissionTimestampDateFilter", () => {
+describe("getLookerSubmissionTimestampDateFilter", () => {
     it("returns the default date filter when startDate and endDate are null", () => {
         const result = getLookerSubmissionTimestampDateFilter(null, null);
 

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -99,8 +99,7 @@ function showCTRMetrics(
   ctrDashboardLink?: string,
   ctrPercent?: number
 ) {
-  // XXX remove infobar condition in https://bugzilla.mozilla.org/show_bug.cgi?id=1905155
-  if (ctrDashboardLink && ctrPercent !== undefined && template !== "infobar") {
+  if (ctrDashboardLink && ctrPercent !== undefined) {
     return OffsiteLink(ctrDashboardLink, ctrPercent + "% CTR");
   } else if (ctrDashboardLink) {
     return OffsiteLink(ctrDashboardLink, "Dashboard");

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -34,7 +34,7 @@ export async function runQueryForTemplate(template: string, filters: any, startD
   const newQueryBody = structuredClone(origQuery)
   delete newQueryBody.client_id // must be unique per-query
 
-  const submission_timestamp_date = getSubmissionTimestampDateFilter(startDate, endDate);
+  const submission_timestamp_date = getLookerSubmissionTimestampDateFilter(startDate, endDate);
 
   // override the filters
   if (template === "infobar") {

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -10,13 +10,7 @@ export async function getAWDashboardElement0(template: string): Promise<IDashboa
   // https://mozilla.cloud.looker.com/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Dashboard/dashboard_element
   // for more info).
 
-  let elements: IDashboardElement[];
-  if (template == "infobar") {
-    // XXX infobar hasn't had its own overview dashboard element created yet
-    // so we're still using the old code here
-    elements = await SDK.ok(SDK.dashboard_dashboard_elements(dashboardId));
-  } else {
-    elements = await SDK.ok(
+  const elements: IDashboardElement[] = await SDK.ok(
       // XXX whether search_dashboard_elements is a net win here isn't
       // clear, but the code is working, so I'm inclined to leave it alone for now.
       SDK.search_dashboard_elements(
@@ -27,7 +21,6 @@ export async function getAWDashboardElement0(template: string): Promise<IDashboa
         }
       )
     )
-  }
 
   return elements[0];
 }
@@ -41,16 +34,17 @@ export async function runQueryForTemplate(template: string, filters: any, startD
   const newQueryBody = structuredClone(origQuery)
   delete newQueryBody.client_id // must be unique per-query
 
+  const submission_timestamp_date = getSubmissionTimestampDateFilter(startDate, endDate);
+
   // override the filters
   if (template === "infobar") {
     newQueryBody.filters = Object.assign(
       {
-        "messaging_system.submission_date": "1 day ago for 1 day",
+        "messaging_system.submission_date": submission_timestamp_date,
       },
       filters
     );
   } else {
-    const submission_timestamp_date = getLookerSubmissionTimestampDateFilter(startDate, endDate);
     newQueryBody.filters = Object.assign(
       {
         "event_counts.submission_timestamp_date": submission_timestamp_date,

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -120,7 +120,7 @@ export function getPreviewLink(message: any): string {
  */
 export function getDashboardIdForTemplate(template: string) {
   if (template === "infobar") {
-    return "1775";
+    return "1809";
   } else {
     return "1806";
   }


### PR DESCRIPTION
[**Bug 1905155**](https://bugzilla.mozilla.org/show_bug.cgi?id=1905155)

Changes made:
- Looker: 
    - Duplicated the infobar dashboard and added a new tile to cover CTR and impressions over a duration of time (see [here](https://mozilla.cloud.looker.com/dashboards/1809?Messaging+System+Ping+Type=infobar&Submission+Date=30+days&Messaging+System+Message+Id=&Normalized+Channel=&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=&Experiment+Branch=))
- Code:
    - Enabled inline CTR for infobar dashboards
    - Updated the dashboard ID for the new infobar dashboards

Note:
- This patch was branched off from #271 and will need to be rebased once that patch lands 