### PR TITLE
Bug 1902122 - Add "first screen" to Looker dashboard title

### DIFF
--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -3,7 +3,7 @@ import { getLookerSubmissionTimestampDateFilter } from "./lookerUtils";
 export function getDisplayNameForTemplate(template: string): string {
   const displayNames: any = {
     aboutwelcome: "About:Welcome Page (1st screen)",
-    defaultaboutwelcome: "Default About:Welcome Message",
+    defaultaboutwelcome: "Default About:Welcome Message (1st screen)",
     feature_callout: "Feature Callout (1st screen)",
     infobar: "InfoBar",
     milestone_message: "Milestone Messages",
@@ -122,6 +122,6 @@ export function getDashboardIdForTemplate(template: string) {
   if (template === "infobar") {
     return "1809";
   } else {
-    return "1806";
+    return "1818";
   }
 }


### PR DESCRIPTION
[**Bug 1902122**](https://bugzilla.mozilla.org/show_bug.cgi?id=1902122)

Changes made:
- Looker:
    - Added "(first screen)" to the Looker dashboard title to a copy of the most recent dashboard ([here](https://mozilla.cloud.looker.com/dashboards/1818?Submission+Timestamp+Date=30+days&Message+ID=%25FAKESPOT%5E_OPTIN%5E_DEFAULT%25&Locale=&Normalized+Country+Code=&Normalized+Channel=&Version=&Metadata+User+Agent+OS=&Branch=&Experiment=))
- Code:
    - Updated the dashboard ID
    - Added "(1st screen)" to the `Default About:Welcome Message` surface 