### PR TITLE
Increasing the static page generation timeout value

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,6 +33,7 @@ const cspHeaderDev = `
 `;
 
 const nextConfig = {
+  staticPageGenerationTimeout: 120,
   async headers() {
     return [
       {


### PR DESCRIPTION
Increasing `staticPageGenerationTimeout` to 120 seconds so the build should run successfully every time. See this [PR](https://github.com/mozilla/skylight/pull/290#issuecomment-2228894675) for more context. 

rs=dmose