### PR TITLE
Bug 1907413 - Link surface tags to experimenter.info docs

### DIFF
--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -61,7 +61,7 @@ function SurfaceTag(template: string, surface: string) {
         className={
           "text-xs/[180%] " +
           surfaceTagClassName +
-          " visited:text-secondary hover:text-blue-800 hover:bg-opacity-80 cursor-pointer no-underline"
+          " visited:text-secondary hover:text-primary hover:bg-opacity-80 cursor-pointer no-underline"
         }
         href={surfaceDoc}
         target="_blank"

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -7,6 +7,23 @@ import { ChevronsUpDown, ChevronDown, ChevronRight } from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import { InfoPopover } from "@/components/ui/infopopover";
 
+function getSurfaceDocs(template: string): string | undefined {
+  const surfaceTagDocs: any = {
+    feature_callout:
+      "https://experimenter.info/messaging/desktop-messaging-surfaces/#feature-callouts",
+    infobar:
+      "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
+    pb_newtab:
+      "https://experimenter.info/messaging/desktop-messaging-surfaces/#privatebrowsing",
+    spotlight:
+      "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
+  };
+
+  if (template in surfaceTagDocs) {
+    return surfaceTagDocs[template];
+  }
+}
+
 function getSurfaceTagColor(template: string): string {
   const surfaceTagColors: any = {
     aboutwelcome: "bg-red-400",
@@ -37,9 +54,27 @@ function SurfaceTag(template: string, surface: string) {
       "px-2 py-1 inline rounded-md " + getSurfaceTagColor(template);
   }
 
-  return (
-    <div className={"text-xs/[180%] " + surfaceTagClassName}>{surface}</div>
-  );
+  const surfaceDoc = getSurfaceDocs(template);
+  if (surfaceDoc) {
+    return (
+      <a
+        className={
+          "text-xs/[180%] " +
+          surfaceTagClassName +
+          " visited:text-secondary hover:text-blue-800 hover:bg-opacity-80 cursor-pointer no-underline"
+        }
+        href={surfaceDoc}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {surface}
+      </a>
+    );
+  } else {
+    return (
+      <div className={"text-xs/[180%] " + surfaceTagClassName}>{surface}</div>
+    );
+  }
 }
 
 function OffsiteLink(href: string, linkText: any) {

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -6,55 +6,17 @@ import { PreviewLinkButton } from "@/components/ui/previewlinkbutton";
 import { ChevronsUpDown, ChevronDown, ChevronRight } from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import { InfoPopover } from "@/components/ui/infopopover";
-
-function getSurfaceDocs(template: string): string | undefined {
-  const surfaceTagDocs: any = {
-    feature_callout:
-      "https://experimenter.info/messaging/desktop-messaging-surfaces/#feature-callouts",
-    infobar:
-      "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
-    pb_newtab:
-      "https://experimenter.info/messaging/desktop-messaging-surfaces/#privatebrowsing",
-    spotlight:
-      "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
-  };
-
-  if (template in surfaceTagDocs) {
-    return surfaceTagDocs[template];
-  }
-}
-
-function getSurfaceTagColor(template: string): string {
-  const surfaceTagColors: any = {
-    aboutwelcome: "bg-red-400",
-    defaultaboutwelcome: "bg-orange-400",
-    feature_callout: "bg-yellow-300",
-    infobar: "bg-lime-300",
-    milestone_message: "bg-green-400",
-    multi: "bg-teal-300",
-    pb_newtab: "bg-sky-400",
-    protections_panel: "bg-blue-500",
-    toast_notification: "bg-indigo-400",
-    toolbar_badge: "bg-purple-400",
-    spotlight: "bg-pink-400",
-    update_action: "bg-rose-400",
-  };
-
-  if (template in surfaceTagColors) {
-    return surfaceTagColors[template];
-  }
-
-  return "";
-}
+import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
 
 function SurfaceTag(template: string, surface: string) {
   let surfaceTagClassName = "";
   if (template !== "none") {
     surfaceTagClassName =
-      "px-2 py-1 inline rounded-md " + getSurfaceTagColor(template);
+      "px-2 py-1 inline rounded-md " +
+      getSurfaceDataForTemplate(template).tagColor;
   }
 
-  const surfaceDoc = getSurfaceDocs(template);
+  const surfaceDoc = getSurfaceDataForTemplate(template).docs;
   if (surfaceDoc) {
     return (
       <a

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -10,16 +10,15 @@ import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
 
 function SurfaceTag(template: string, surface: string) {
   const { tagColor, docs } = getSurfaceDataForTemplate(template);
+  const anchorTagClassName =
+    "text-primary visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer hover:no-underline ";
   const surfaceTagClassName =
     "text-xs/[180%] text-nowrap px-2 py-1 inline rounded-md " + tagColor;
 
   if (docs) {
     return (
       <a
-        className={
-          "visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer hover:no-underline " +
-          surfaceTagClassName
-        }
+        className={anchorTagClassName + surfaceTagClassName}
         href={docs}
         target="_blank"
         rel="noreferrer"

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -59,9 +59,9 @@ function SurfaceTag(template: string, surface: string) {
     return (
       <a
         className={
-          "text-xs/[180%] " +
+          "text-xs/[180%] text-nowrap " +
           surfaceTagClassName +
-          " visited:text-secondary hover:text-primary hover:bg-opacity-80 cursor-pointer no-underline"
+          " visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer no-underline"
         }
         href={surfaceDoc}
         target="_blank"
@@ -72,7 +72,9 @@ function SurfaceTag(template: string, surface: string) {
     );
   } else {
     return (
-      <div className={"text-xs/[180%] " + surfaceTagClassName}>{surface}</div>
+      <div className={"text-xs/[180%] text-nowrap " + surfaceTagClassName}>
+        {surface}
+      </div>
     );
   }
 }

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -39,7 +39,7 @@ function SurfaceTag(template: string, surface: string) {
         className={
           "text-xs/[180%] text-nowrap " +
           surfaceTagClassName +
-          " visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer no-underline"
+          " visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer hover:no-underline"
         }
         href={surfaceDoc}
         target="_blank"

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -9,11 +9,27 @@ import { InfoPopover } from "@/components/ui/infopopover";
 import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
 
 function SurfaceTag(template: string, surface: string) {
+  const tagColors = [
+    "bg-red-400",
+    "bg-orange-400",
+    "bg-yellow-300",
+    "bg-lime-300",
+    "bg-green-400",
+    "bg-teal-300",
+    "bg-sky-400",
+    "bg-blue-500",
+    "bg-indigo-400",
+    "bg-purple-400",
+    "bg-pink-400",
+    "bg-rose-400",
+    "bg-fuchsia-300",
+  ];
+
   let surfaceTagClassName = "";
-  if (template !== "none") {
+  const tagColorIndex = getSurfaceDataForTemplate(template).tagColorIndex;
+  if (template !== "none" && tagColorIndex >= 0) {
     surfaceTagClassName =
-      "px-2 py-1 inline rounded-md " +
-      getSurfaceDataForTemplate(template).tagColor;
+      "px-2 py-1 inline rounded-md " + tagColors[tagColorIndex];
   }
 
   const surfaceDoc = getSurfaceDataForTemplate(template).docs;

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -9,39 +9,18 @@ import { InfoPopover } from "@/components/ui/infopopover";
 import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
 
 function SurfaceTag(template: string, surface: string) {
-  const tagColors = [
-    "bg-red-400",
-    "bg-orange-400",
-    "bg-yellow-300",
-    "bg-lime-300",
-    "bg-green-400",
-    "bg-teal-300",
-    "bg-sky-400",
-    "bg-blue-500",
-    "bg-indigo-400",
-    "bg-purple-400",
-    "bg-pink-400",
-    "bg-rose-400",
-    "bg-fuchsia-300",
-  ];
+  const { tagColor, docs } = getSurfaceDataForTemplate(template);
+  const surfaceTagClassName =
+    "text-xs/[180%] text-nowrap px-2 py-1 inline rounded-md " + tagColor;
 
-  let surfaceTagClassName = "";
-  const tagColorIndex = getSurfaceDataForTemplate(template).tagColorIndex;
-  if (template !== "none" && tagColorIndex >= 0) {
-    surfaceTagClassName =
-      "px-2 py-1 inline rounded-md " + tagColors[tagColorIndex];
-  }
-
-  const surfaceDoc = getSurfaceDataForTemplate(template).docs;
-  if (surfaceDoc) {
+  if (docs) {
     return (
       <a
         className={
-          "text-xs/[180%] text-nowrap " +
-          surfaceTagClassName +
-          " visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer hover:no-underline"
+          "visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer hover:no-underline " +
+          surfaceTagClassName
         }
-        href={surfaceDoc}
+        href={docs}
         target="_blank"
         rel="noreferrer"
       >
@@ -49,11 +28,7 @@ function SurfaceTag(template: string, surface: string) {
       </a>
     );
   } else {
-    return (
-      <div className={"text-xs/[180%] text-nowrap " + surfaceTagClassName}>
-        {surface}
-      </div>
-    );
+    return <div className={surfaceTagClassName}>{surface}</div>;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import {
 import { getCTRPercentData } from "@/lib/looker.ts";
 import {
   getDashboard,
-  getDisplayNameForTemplate,
+  getSurfaceDataForTemplate,
   getTemplateFromMessage,
   _isAboutWelcomeTemplate,
   maybeCreateWelcomePreview,
@@ -34,7 +34,8 @@ async function getASRouterLocalColumnFromJSON(
     product: "Desktop",
     id: messageDef.id,
     template: messageDef.template,
-    surface: getDisplayNameForTemplate(getTemplateFromMessage(messageDef)),
+    surface: getSurfaceDataForTemplate(getTemplateFromMessage(messageDef))
+      .surface,
     segment: "some segment",
     metrics: "some metrics",
     ctrPercent: undefined, // may be populated from Looker data

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -2,7 +2,7 @@ import { getLookerSubmissionTimestampDateFilter } from "./lookerUtils";
 
 export type SurfaceData = {
   surface: string;
-  tagColorIndex: number;
+  tagColor?: string;
   docs?: string;
 };
 
@@ -10,51 +10,55 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
   const surfaceData: Record<string, SurfaceData> = {
     aboutwelcome: {
       surface: "About:Welcome Page (1st screen)",
-      tagColorIndex: 0,
+      tagColor: "bg-red-400",
     },
     defaultaboutwelcome: {
       surface: "Default About:Welcome Message (1st screen)",
-      tagColorIndex: 1,
+      tagColor: "bg-orange-400",
     },
     feature_callout: {
       surface: "Feature Callout (1st screen)",
-      tagColorIndex: 2,
+      tagColor: "bg-yellow-300",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#feature-callouts",
     },
     infobar: {
       surface: "InfoBar",
-      tagColorIndex: 3,
+      tagColor: "bg-lime-300",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
     },
     milestone_message: {
       surface: "Milestone Messages",
-      tagColorIndex: 4,
+      tagColor: "bg-green-400",
     },
     multi: {
       surface: "1st of Multiple Messages",
-      tagColorIndex: 5,
+      tagColor: "bg-teal-300",
     },
     pb_newtab: {
       surface: "Private Browsing New Tab",
-      tagColorIndex: 6,
+      tagColor: "bg-sky-400",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#privatebrowsing",
     },
     protections_panel: {
       surface: "Protections Dropdown Panel",
-      tagColorIndex: 7,
+      tagColor: "bg-blue-500",
     },
     toast_notification: {
       surface: "Toast Notification",
-      tagColorIndex: 8,
+      tagColor: "bg-indigo-400",
     },
-    toolbar_badge: { surface: "Toolbar Badge", tagColorIndex: 9 },
+    toolbar_badge: { surface: "Toolbar Badge", tagColor: "bg-purple-400" },
     spotlight: {
       surface: "Spotlight Modal Dialog",
-      tagColorIndex: 10,
+      tagColor: "bg-pink-400",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
     },
-    update_action: { surface: "Moments Page", tagColorIndex: 11 },
-    whatsNewPage: { surface: "What's New Page", tagColorIndex: 12 },
+    update_action: {
+      surface: "Moments Page",
+      tagColor: "bg-rose-400",
+      docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#moments-pages",
+    },
+    whatsNewPage: { surface: "What's New Page", tagColor: "bg-fuchsia-300" },
   };
 
   if (template in surfaceData) {
@@ -63,7 +67,6 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
 
   return {
     surface: template,
-    tagColorIndex: -1,
   };
 }
 

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -54,6 +54,7 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
     },
     update_action: { surface: "Moments Page", tagColor: "bg-rose-400" },
+    whatsNewPage: { surface: "What's New Page", tagColor: "bg-fuchsia-300" },
   };
 
   if (template in surfaceData) {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -2,7 +2,7 @@ import { getLookerSubmissionTimestampDateFilter } from "./lookerUtils";
 
 export type SurfaceData = {
   surface: string;
-  tagColor: string;
+  tagColorIndex: number;
   docs?: string;
 };
 
@@ -10,51 +10,51 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
   const surfaceData: Record<string, SurfaceData> = {
     aboutwelcome: {
       surface: "About:Welcome Page (1st screen)",
-      tagColor: "bg-red-400",
+      tagColorIndex: 0,
     },
     defaultaboutwelcome: {
       surface: "Default About:Welcome Message (1st screen)",
-      tagColor: "bg-orange-400",
+      tagColorIndex: 1,
     },
     feature_callout: {
       surface: "Feature Callout (1st screen)",
-      tagColor: "bg-yellow-300",
+      tagColorIndex: 2,
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#feature-callouts",
     },
     infobar: {
       surface: "InfoBar",
-      tagColor: "bg-lime-300",
+      tagColorIndex: 3,
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
     },
     milestone_message: {
       surface: "Milestone Messages",
-      tagColor: "bg-green-400",
+      tagColorIndex: 4,
     },
     multi: {
       surface: "1st of Multiple Messages",
-      tagColor: "bg-teal-300",
+      tagColorIndex: 5,
     },
     pb_newtab: {
       surface: "Private Browsing New Tab",
-      tagColor: "bg-sky-400",
+      tagColorIndex: 6,
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#privatebrowsing",
     },
     protections_panel: {
       surface: "Protections Dropdown Panel",
-      tagColor: "bg-blue-500",
+      tagColorIndex: 7,
     },
     toast_notification: {
       surface: "Toast Notification",
-      tagColor: "bg-indigo-400",
+      tagColorIndex: 8,
     },
-    toolbar_badge: { surface: "Toolbar Badge", tagColor: "bg-purple-400" },
+    toolbar_badge: { surface: "Toolbar Badge", tagColorIndex: 9 },
     spotlight: {
       surface: "Spotlight Modal Dialog",
-      tagColor: "bg-pink-400",
+      tagColorIndex: 10,
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
     },
-    update_action: { surface: "Moments Page", tagColor: "bg-rose-400" },
-    whatsNewPage: { surface: "What's New Page", tagColor: "bg-fuchsia-300" },
+    update_action: { surface: "Moments Page", tagColorIndex: 11 },
+    whatsNewPage: { surface: "What's New Page", tagColorIndex: 12 },
   };
 
   if (template in surfaceData) {
@@ -63,7 +63,7 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
 
   return {
     surface: template,
-    tagColor: "bg-slate-200",
+    tagColorIndex: -1,
   };
 }
 

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -1,26 +1,69 @@
 import { getLookerSubmissionTimestampDateFilter } from "./lookerUtils";
 
-export function getDisplayNameForTemplate(template: string): string {
-  const displayNames: any = {
-    aboutwelcome: "About:Welcome Page (1st screen)",
-    defaultaboutwelcome: "Default About:Welcome Message (1st screen)",
-    feature_callout: "Feature Callout (1st screen)",
-    infobar: "InfoBar",
-    milestone_message: "Milestone Messages",
-    multi: "1st of Multiple Messages",
-    pb_newtab: "Private Browsing New Tab",
-    protections_panel: "Protections Dropdown Panel",
-    toast_notification: "Toast Notification",
-    toolbar_badge: "Toolbar Badge",
-    spotlight: "Spotlight Modal Dialog",
-    update_action: "Moments Page",
+export type SurfaceData = {
+  surface: string;
+  tagColor: string;
+  docs?: string;
+};
+
+export function getSurfaceDataForTemplate(template: string): SurfaceData {
+  const surfaceData: Record<string, SurfaceData> = {
+    aboutwelcome: {
+      surface: "About:Welcome Page (1st screen)",
+      tagColor: "bg-red-400",
+    },
+    defaultaboutwelcome: {
+      surface: "Default About:Welcome Message (1st screen)",
+      tagColor: "bg-orange-400",
+    },
+    feature_callout: {
+      surface: "Feature Callout (1st screen)",
+      tagColor: "bg-yellow-300",
+      docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#feature-callouts",
+    },
+    infobar: {
+      surface: "InfoBar",
+      tagColor: "bg-lime-300",
+      docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
+    },
+    milestone_message: {
+      surface: "Milestone Messages",
+      tagColor: "bg-green-400",
+    },
+    multi: {
+      surface: "1st of Multiple Messages",
+      tagColor: "bg-teal-300",
+    },
+    pb_newtab: {
+      surface: "Private Browsing New Tab",
+      tagColor: "bg-sky-400",
+      docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#privatebrowsing",
+    },
+    protections_panel: {
+      surface: "Protections Dropdown Panel",
+      tagColor: "bg-blue-500",
+    },
+    toast_notification: {
+      surface: "Toast Notification",
+      tagColor: "bg-indigo-400",
+    },
+    toolbar_badge: { surface: "Toolbar Badge", tagColor: "bg-purple-400" },
+    spotlight: {
+      surface: "Spotlight Modal Dialog",
+      tagColor: "bg-pink-400",
+      docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
+    },
+    update_action: { surface: "Moments Page", tagColor: "bg-rose-400" },
   };
 
-  if (template in displayNames) {
-    return displayNames[template];
+  if (template in surfaceData) {
+    return surfaceData[template];
   }
 
-  return template;
+  return {
+    surface: template,
+    tagColor: "bg-slate-200",
+  };
 }
 
 export function getTemplateFromMessage(msg: any): string {

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -77,7 +77,7 @@ export class NimbusRecipe implements NimbusRecipeType {
     let template;
     if (feature.featureId === "aboutwelcome" && branch.slug != "control") {
       template = "aboutwelcome";
-    } else if (feature.featureId === "whatsNewPage") {
+    } else if (feature.featureId === "whatsNewPage" && branch.slug != "control") {
       // XXX whatsNewPage doesn't have a template property so we need to
       // assign it directly in order for it to display a surface
       template = "whatsNewPage";

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -2,7 +2,7 @@ import { types } from "@mozilla/nimbus-shared";
 import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "../app/columns.jsx";
 import {
   getDashboard,
-  getDisplayNameForTemplate,
+  getSurfaceDataForTemplate,
   getPreviewLink,
   getTemplateFromMessage,
 } from "../lib/messageUtils.ts";
@@ -83,7 +83,7 @@ export class NimbusRecipe implements NimbusRecipeType {
 
     branch.template = template;
     branchInfo.template = template;
-    branchInfo.surface = getDisplayNameForTemplate(template);
+    branchInfo.surface = getSurfaceDataForTemplate(template).surface;
 
     switch (template) {
       case "aboutwelcome":

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -77,6 +77,10 @@ export class NimbusRecipe implements NimbusRecipeType {
     let template;
     if (feature.featureId === "aboutwelcome" && branch.slug != "control") {
       template = "aboutwelcome";
+    } else if (feature.featureId === "whatsNewPage") {
+      // XXX whatsNewPage doesn't have a template property so we need to
+      // assign it directly in order for it to display a surface
+      template = "whatsNewPage";
     } else {
       template = getTemplateFromMessage(feature.value);
     }

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -77,7 +77,10 @@ export class NimbusRecipe implements NimbusRecipeType {
     let template;
     if (feature.featureId === "aboutwelcome" && branch.slug != "control") {
       template = "aboutwelcome";
-    } else if (feature.featureId === "whatsNewPage" && branch.slug != "control") {
+    } else if (
+      feature.featureId === "whatsNewPage" &&
+      branch.slug != "control"
+    ) {
       // XXX whatsNewPage doesn't have a template property so we need to
       // assign it directly in order for it to display a surface
       template = "whatsNewPage";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,7 @@ const config = {
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {


### PR DESCRIPTION
[**Bug 1907413**](https://bugzilla.mozilla.org/show_bug.cgi?id=1907413)

Changes made:
- Link surface tags to the appropriate docs with screenshots of the surface
- Fixed surface tags to not wrap
- Added surface tags to WNP messages

Note:
- This PR is branched off from #306 so it will need to be rebased before merging