### PR TITLE
Bug 1898808 - Move links outside from Messaging Info menu button

### DIFF
--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -11,7 +11,7 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import { Menu, Hash } from "lucide-react";
+import { Menu, Hash, Book, AppWindow } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ListItem = React.forwardRef<
@@ -48,30 +48,44 @@ export function MenuButton() {
           <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
             <a
               className="no-underline flex text-primary hover:bg-accent hover:text-accent-foreground visited:text-inherit"
+              href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
+            >
+              <AppWindow size={20} className="mr-1" />
+              Messaging Surfaces
+            </a>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+            <a
+              className="no-underline flex text-primary hover:bg-accent hover:text-accent-foreground visited:text-inherit"
+              href="https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/index.html"
+            >
+              <Book size={20} className="mr-1" />
+              Technical Docs
+            </a>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+            <a
+              className="no-underline flex text-primary hover:bg-accent hover:text-accent-foreground visited:text-inherit"
               href="https://mozilla.slack.com/archives/C05N15KHCLC"
             >
-              <Hash className="mr-1" />
+              <Hash size={20} className="mr-1" />
               Help/Feedback
             </a>
           </NavigationMenuLink>
         </NavigationMenuItem>
         <NavigationMenuItem>
           <NavigationMenuTrigger>
-            <Menu className="mr-1" /> Messaging Info
+            <Menu size={20} className="mr-1" /> Messaging Info
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+            <ul className="grid gap-3 p-6 md:w-[300px] lg:w-[400px]">
               <ListItem
                 href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team"
                 title="OMC Team Info"
-              />
-              <ListItem
-                href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
-                title="Messaging Surfaces"
-              />
-              <ListItem
-                href="https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/index.html"
-                title="Technical Documentation"
               />
               <ListItem
                 href="https://mozilla.cloud.looker.com/dashboards/1461?Normalized+Channel=release"

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -42,7 +42,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
 );
 
 const NavigationMenuTrigger = React.forwardRef<


### PR DESCRIPTION
[**Bug 1898808**](https://bugzilla.mozilla.org/show_bug.cgi?id=1898808)

Changes made:
- Moved some links outside the Messaging Info menu button into the header for more visibility 

Notes:
- I'm open for suggestions on moving more/less links in/out of the Messaging Info menu button