### PR TITLE
Bug 1909531 - Make table title and headers sticky

### DIFF
--- a/app/complete/page.tsx
+++ b/app/complete/page.tsx
@@ -91,7 +91,7 @@ export default async function CompleteExperimentsDashboard() {
 
   return (
     <div>
-      <div className="flex justify-between mx-20 py-8">
+      <div className="sticky top-0 z-50 bg-background flex justify-between mx-20 py-8">
         <h4 className="scroll-m-20 text-3xl font-semibold">Skylight</h4>
         <MenuButton isComplete={true} />
       </div>
@@ -105,7 +105,7 @@ export default async function CompleteExperimentsDashboard() {
       <h5 className="scroll-m-20 text-sm text-center">
         Total: {totalRolloutExperiments}
       </h5>
-      <div className="flex justify-center">
+      <div className="sticky top-24 z-10 py-2 bg-background flex justify-center">
         <Timeline active="rollout" />
       </div>
       <div className="container mx-auto py-10">
@@ -125,7 +125,7 @@ export default async function CompleteExperimentsDashboard() {
       <h5 className="scroll-m-20 text-sm text-center">
         Total: {totalExperiments}
       </h5>
-      <div className="flex justify-center">
+      <div className="sticky top-24 z-10 py-2 bg-background flex justify-center">
         <Timeline active="experiment" />
       </div>
       <div className="space-y-5 container mx-auto py-10">

--- a/app/message-table.tsx
+++ b/app/message-table.tsx
@@ -59,7 +59,7 @@ export function MessageTable<TData, TValue>({
   return (
     <div className="rounded-md border">
       <Table>
-        <TableHeader className="sticky top-32">
+        <TableHeader className="sticky top-36">
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => {

--- a/app/message-table.tsx
+++ b/app/message-table.tsx
@@ -18,7 +18,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-import { BranchInfo } from "./columns.tsx";
 import { useState } from "react";
 
 interface MessageTableProps<TData, TValue> {
@@ -60,7 +59,7 @@ export function MessageTable<TData, TValue>({
   return (
     <div className="rounded-md border">
       <Table>
-        <TableHeader>
+        <TableHeader className="sticky top-32">
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,7 +177,7 @@ export default async function Dashboard() {
 
   return (
     <div>
-      <div className="flex justify-between mx-20 py-8">
+      <div className="sticky top-0 z-10 bg-background flex justify-between px-20 py-8">
         <h4 className="scroll-m-20 text-3xl font-semibold">Skylight</h4>
         <MenuButton isComplete={false} />
       </div>
@@ -190,7 +190,7 @@ export default async function Dashboard() {
         />
       </h5>
       <h5 className="scroll-m-20 text-sm text-center">(Partial List)</h5>
-      <div className="flex justify-center">
+      <div className="sticky top-20 z-10 bg-background py-2 flex justify-center">
         <Timeline active="firefox" />
       </div>
 
@@ -207,7 +207,7 @@ export default async function Dashboard() {
       <h5 className="scroll-m-20 text-sm text-center">
         Total: {totalRolloutExperiments}
       </h5>
-      <div className="flex justify-center">
+      <div className="sticky top-20 z-10 bg-background py-2 flex justify-center">
         <Timeline active="rollout" />
       </div>
       <div className="container mx-auto py-10">
@@ -227,7 +227,7 @@ export default async function Dashboard() {
       <h5 className="scroll-m-20 text-sm text-center">
         Total: {totalExperiments}
       </h5>
-      <div className="flex justify-center">
+      <div className="sticky top-20 z-10 bg-background py-2 flex justify-center">
         <Timeline active="experiment" />
       </div>
       <div className="space-y-5 container mx-auto py-10">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,7 +177,7 @@ export default async function Dashboard() {
 
   return (
     <div>
-      <div className="sticky top-0 z-10 bg-background flex justify-between px-20 py-8">
+      <div className="sticky top-0 z-50 bg-background flex justify-between px-20 py-8">
         <h4 className="scroll-m-20 text-3xl font-semibold">Skylight</h4>
         <MenuButton isComplete={false} />
       </div>
@@ -190,7 +190,7 @@ export default async function Dashboard() {
         />
       </h5>
       <h5 className="scroll-m-20 text-sm text-center">(Partial List)</h5>
-      <div className="sticky top-20 z-10 bg-background py-2 flex justify-center">
+      <div className="sticky top-24 z-10 bg-background py-2 flex justify-center">
         <Timeline active="firefox" />
       </div>
 
@@ -207,7 +207,7 @@ export default async function Dashboard() {
       <h5 className="scroll-m-20 text-sm text-center">
         Total: {totalRolloutExperiments}
       </h5>
-      <div className="sticky top-20 z-10 bg-background py-2 flex justify-center">
+      <div className="sticky top-24 z-10 bg-background py-2 flex justify-center">
         <Timeline active="rollout" />
       </div>
       <div className="container mx-auto py-10">
@@ -227,7 +227,7 @@ export default async function Dashboard() {
       <h5 className="scroll-m-20 text-sm text-center">
         Total: {totalExperiments}
       </h5>
-      <div className="sticky top-20 z-10 bg-background py-2 flex justify-center">
+      <div className="sticky top-24 z-10 bg-background py-2 flex justify-center">
         <Timeline active="experiment" />
       </div>
       <div className="space-y-5 container mx-auto py-10">

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,13 +6,11 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
+  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />
 ));
 Table.displayName = "Table";
 


### PR DESCRIPTION
[**Bug 1909531**](https://bugzilla.mozilla.org/show_bug.cgi?id=1909531)

Changes made:
- Made the timeline component and table headers sticky

Note:
- May have to rebase if #314 gets merged first to ensure the completed page also has sticky headers