### PR TITLE
Bug 1909233 - Add search experiment/rollout briefs link to header

### DIFF
--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -10,6 +10,7 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
+  navigationMenuItemStyle,
 } from "@/components/ui/navigation-menu";
 import { Menu, Hash, Book, AppWindow, Table, FileSearch } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -52,7 +53,7 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
     <NavigationMenu>
       <NavigationMenuList>
         <NavigationMenuItem>
-          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+          <NavigationMenuLink asChild className={navigationMenuItemStyle()}>
             <a
               className={navMenuItemClassName}
               href="https://drive.google.com/drive/u/0/folders/1Jx7X_aFqvVCQYah9eOALvypZJdMf21F2"
@@ -63,7 +64,7 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
           </NavigationMenuLink>
         </NavigationMenuItem>
         <NavigationMenuItem>
-          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+          <NavigationMenuLink asChild className={navigationMenuItemStyle()}>
             <a
               className={navMenuItemClassName}
               href={isComplete ? "/" : "/complete"}
@@ -74,7 +75,7 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
           </NavigationMenuLink>
         </NavigationMenuItem>
         <NavigationMenuItem>
-          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+          <NavigationMenuLink asChild className={navigationMenuItemStyle()}>
             <a
               className={navMenuItemClassName}
               href="https://mozilla.slack.com/archives/C05N15KHCLC"

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -11,7 +11,7 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import { Menu, Hash, Book, AppWindow, Table } from "lucide-react";
+import { Menu, Hash, Book, AppWindow, Table, FileSearch } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ListItem = React.forwardRef<
@@ -51,6 +51,17 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
   return (
     <NavigationMenu>
       <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+            <a
+              className={navMenuItemClassName}
+              href="https://drive.google.com/drive/u/0/folders/1Jx7X_aFqvVCQYah9eOALvypZJdMf21F2"
+            >
+              <FileSearch size={iconSize} />
+              Search Briefs
+            </a>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
         <NavigationMenuItem>
           <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
             <a

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -77,28 +77,6 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
           <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
             <a
               className={navMenuItemClassName}
-              href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
-            >
-              <AppWindow size={iconSize} />
-              Messaging Surfaces
-            </a>
-          </NavigationMenuLink>
-        </NavigationMenuItem>
-        <NavigationMenuItem>
-          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
-            <a
-              className={navMenuItemClassName}
-              href="https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/index.html"
-            >
-              <Book size={iconSize} />
-              Technical Docs
-            </a>
-          </NavigationMenuLink>
-        </NavigationMenuItem>
-        <NavigationMenuItem>
-          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
-            <a
-              className={navMenuItemClassName}
               href="https://mozilla.slack.com/archives/C05N15KHCLC"
             >
               <Hash size={iconSize} />
@@ -111,7 +89,15 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
             <Menu size={iconSize} className="mr-1" /> Messaging Info
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="grid gap-3 p-6 md:w-[300px] lg:w-[400px]">
+            <ul className="grid gap-3 p-4 md:w-[300px] lg:w-[400px]">
+              <ListItem
+                href="https://experimenter.info/messaging/desktop-messaging-surfaces/"
+                title="Messaging Surfaces"
+              />
+              <ListItem
+                href="https://firefox-source-docs.mozilla.org/browser/components/asrouter/docs/index.html"
+                title="Technical Docs"
+              />
               <ListItem
                 href="https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/11043366/Onboarding+Messaging+Communication+OMC+Engineering+Team"
                 title="OMC Team Info"

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -42,6 +42,10 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-xs font-medium transition-colors border hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
+);
+
+const navigationMenuItemStyle = cva(
   "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
 );
 
@@ -122,4 +126,5 @@ export {
   NavigationMenuLink,
   NavigationMenuIndicator,
   NavigationMenuViewport,
+  navigationMenuItemStyle,
 };


### PR DESCRIPTION
[**Bug 1909233**](https://bugzilla.mozilla.org/show_bug.cgi?id=1909233)

Changes made:
- Added a link in the header that leads to the Google Drive with all experiment briefs

Questions:
- Is the header getting too crowded? Not sure if I should move "Message Surfaces" link inside the "Messaging Info" button since surface tags will link to the same doc. 
- Is "Search briefs" informative enough?