### PR TITLE
Make preview button tooltips more clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Friday, August 16th, 2024
 
-### Changed 
+### Changed
 
 - Updated the preview button tooltips to be more comprehensive
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Friday, August 16th, 2024
+
+### Changed 
+
+- Updated the preview button tooltips to be more comprehensive
+
 ## Tuesday, August 6th, 2024
 
 ### Added

--- a/components/ui/previewlinkbutton.tsx
+++ b/components/ui/previewlinkbutton.tsx
@@ -35,7 +35,9 @@ export function PreviewLinkButton(linkObject: any) {
         <TooltipContent>
           <p className="w-80">
             To preview, set{" "}
-            <code>browser.newtabpage.activity-stream.asrouter.devtoolsEnabled</code>{" "}
+            <code>
+              browser.newtabpage.activity-stream.asrouter.devtoolsEnabled
+            </code>{" "}
             to true; Firefox 128 or newer is required.
           </p>
         </TooltipContent>

--- a/components/ui/previewlinkbutton.tsx
+++ b/components/ui/previewlinkbutton.tsx
@@ -33,9 +33,10 @@ export function PreviewLinkButton(linkObject: any) {
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>
-            After clicking to copy, paste in (Fx 128+ &gt;= June 4th only) URL
-            bar for message preview
+          <p className="w-80">
+            To preview, set{" "}
+            <code>browser.newtabpage.activity-stream.asrouter.devtoolsEnabled</code>{" "}
+            to true; Firefox 128 or newer is required.
           </p>
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
Quick PR to make the preview button tooltips clearer; they now mention the devtools pref that needs to be set for previews to work. This is for the Mozweek demo and we can tweak it later if need be :)