### PR TITLE
Bug 1916839 - Update URL for searching briefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Thursday, September 5th, 2024
+
+### Fixed
+
+- Updated the URL in the "Search Briefs" button to start a search in Google Drive for experiment briefs
+
 ## Friday, August 30th, 2024
 
 ### Added

--- a/components/ui/menubutton.tsx
+++ b/components/ui/menubutton.tsx
@@ -56,7 +56,7 @@ export function MenuButton({ isComplete }: MenuButtonProps) {
           <NavigationMenuLink asChild className={navigationMenuItemStyle()}>
             <a
               className={navMenuItemClassName}
-              href="https://drive.google.com/drive/u/0/folders/1Jx7X_aFqvVCQYah9eOALvypZJdMf21F2"
+              href="https://drive.google.com/drive/u/0/search?q=parent:1Jx7X_aFqvVCQYah9eOALvypZJdMf21F2"
             >
               <FileSearch size={iconSize} />
               Search Briefs


### PR DESCRIPTION
[Bug 1916839](https://bugzilla.mozilla.org/show_bug.cgi?id=1916839)

Changes made:
- Updated the URL for the "Search Briefs" link in the header to start a search within the experiment briefs