### PR TITLE
Bug 1921080 - Expose dashboard links to completed messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Thursday, Spetember 26th, 2024
+
+### Added
+
+- Exposed dashboard links to completed rollouts and experiments
+
 ## Thursday, September 5th, 2024
 
 ### Fixed

--- a/__tests__/ExperimentFakes.mjs
+++ b/__tests__/ExperimentFakes.mjs
@@ -32,6 +32,7 @@ export const ExperimentFakes = {
         "testFeature",
       ],
       isRollout: false,
+      _isCompleted: false,
       ...props,
     };
   },

--- a/__tests__/lib/lookerUtils.test.ts
+++ b/__tests__/lib/lookerUtils.test.ts
@@ -65,4 +65,18 @@ describe("getLookerSubmissionTimestampDateFilter", () => {
 
     expect(result).toEqual("2024-05-08 to 3024-06-10");
   });
+
+  it("returns a date filter from the startDate to endDate when startDate and endDate are defined and the message is completed", () => {
+    const startDate = "2024-05-08";
+    const endDate = "2024-06-10";
+    const isCompleted = true;
+
+    const result = getLookerSubmissionTimestampDateFilter(
+      startDate,
+      endDate,
+      isCompleted,
+    );
+
+    expect(result).toEqual("2024-05-08 to 2024-06-10");
+  });
 });

--- a/__tests__/lib/lookerUtils.test.ts
+++ b/__tests__/lib/lookerUtils.test.ts
@@ -34,8 +34,8 @@ describe("getExperimentLookerDashboardDate", () => {
 });
 
 describe("getLookerSubmissionTimestampDateFilter", () => {
-  it("returns the default date filter when startDate and endDate are null", () => {
-    const result = getLookerSubmissionTimestampDateFilter(null, null);
+  it("returns the default date filter when startDate and endDate are undefined", () => {
+    const result = getLookerSubmissionTimestampDateFilter();
 
     expect(result).toEqual("30 day ago for 30 day");
   });

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -7,6 +7,7 @@ import { ChevronsUpDown, ChevronDown, ChevronRight } from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import { InfoPopover } from "@/components/ui/infopopover";
 import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
+import { HIDE_DASHBOARD_EXPERIMENTS } from "@/lib/experimentUtils";
 
 function SurfaceTag(template: string, surface: string) {
   const { tagColor, docs } = getSurfaceDataForTemplate(template);
@@ -426,14 +427,8 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
       </div>
     ),
     cell: (props: any) => {
-      // XXX these dashboards are currently (incorrectly) empty.
-      // Until we fix the upcase bug, we'll hide them
-      const hideDashboardExperiments = [
-        "recommend-media-addons-feature-existing-users",
-        "recommend-media-addons-feature-callout",
-      ];
       if (
-        hideDashboardExperiments.includes(
+        HIDE_DASHBOARD_EXPERIMENTS.includes(
           props.row.original?.nimbusExperiment?.slug,
         )
       ) {
@@ -611,14 +606,8 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     accessorKey: "metrics",
     header: () => "Metrics",
     cell: (props: any) => {
-      // XXX these dashboards are currently (incorrectly) empty.
-      // Until we fix the upcase bug, we'll hide them
-      const hideDashboardExperiments = [
-        "recommend-media-addons-feature-existing-users",
-        "recommend-media-addons-feature-callout",
-      ];
       if (
-        hideDashboardExperiments.includes(
+        HIDE_DASHBOARD_EXPERIMENTS.includes(
           props.row.original?.nimbusExperiment?.slug,
         )
       ) {

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -608,6 +608,30 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     },
   },
   {
+    accessorKey: "metrics",
+    header: () => "Metrics",
+    cell: (props: any) => {
+      // XXX these dashboards are currently (incorrectly) empty.
+      // Until we fix the upcase bug, we'll hide them
+      const hideDashboardExperiments = [
+        "recommend-media-addons-feature-existing-users",
+        "recommend-media-addons-feature-callout",
+      ];
+      if (
+        hideDashboardExperiments.includes(
+          props.row.original?.nimbusExperiment?.slug,
+        )
+      ) {
+        return <></>;
+      }
+
+      if (props.row.original.ctrDashboardLink) {
+        return OffsiteLink(props.row.original.ctrDashboardLink, "Dashboard");
+      }
+      return <></>;
+    },
+  },
+  {
     accessorKey: "other",
     header: () => (
       <div className="flex flex-row items-center">

--- a/lib/experimentUtils.ts
+++ b/lib/experimentUtils.ts
@@ -37,6 +37,17 @@ export const MESSAGING_EXPERIMENTS_DEFAULT_FEATURES: string[] = [
 ];
 
 /**
+ * These are experiment with dashboard links that are currently (incorrectly 
+ * empty).
+ * 
+ * XXX Until we fix the upcase bug, we'll be hiding these dashboards.
+ */
+export const HIDE_DASHBOARD_EXPERIMENTS: string[] = [
+  "recommend-media-addons-feature-existing-users",
+  "recommend-media-addons-feature-callout",
+];
+
+/**
  *
  * @param startDate - may be null, as NimbusExperiment types allow this.
  *                    returns null in this case.
@@ -58,6 +69,19 @@ export function getProposedEndDate(
   const formattedDate = jsDate.toISOString().slice(0, 10);
 
   return formattedDate;
+}
+
+/**
+ * 
+ * @param dateString The date to format in a string.
+ * @param daysToAdd Optional number of days to add from dateString. A
+ *        negative value will result in days subtracted from dateString.
+ * @returns The dateString + daysToAdd as a string value in ISO format.
+ */
+export function formatDate(dateString: string, daysToAdd: number = 0) {
+  const date = new Date(dateString);
+  date.setUTCDate(date.getUTCDate() + daysToAdd);
+  return date.toISOString().slice(0, 10);
 }
 
 // XXX this should really be a method on NimbusRecipe, though it'll need some

--- a/lib/experimentUtils.ts
+++ b/lib/experimentUtils.ts
@@ -37,9 +37,9 @@ export const MESSAGING_EXPERIMENTS_DEFAULT_FEATURES: string[] = [
 ];
 
 /**
- * These are experiment with dashboard links that are currently (incorrectly 
+ * These are experiment with dashboard links that are currently (incorrectly
  * empty).
- * 
+ *
  * XXX Until we fix the upcase bug, we'll be hiding these dashboards.
  */
 export const HIDE_DASHBOARD_EXPERIMENTS: string[] = [
@@ -72,7 +72,7 @@ export function getProposedEndDate(
 }
 
 /**
- * 
+ *
  * @param dateString The date to format in a string.
  * @param daysToAdd Optional number of days to add from dateString. A
  *        negative value will result in days subtracted from dateString.

--- a/lib/lookerUtils.ts
+++ b/lib/lookerUtils.ts
@@ -30,11 +30,14 @@ export function getExperimentLookerDashboardDate(
 export function getLookerSubmissionTimestampDateFilter(
   startDate?: string | null,
   endDate?: string | null,
+  isCompleted?: boolean,
 ): string {
   // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
   let submission_timestamp_date = "30 day ago for 30 day";
 
-  if (startDate && endDate && new Date() < new Date(endDate)) {
+  if (!isCompleted && startDate && endDate && new Date() < new Date(endDate)) {
+    submission_timestamp_date = `${startDate} to ${endDate}`;
+  } else if (isCompleted && startDate && endDate) {
     submission_timestamp_date = `${startDate} to ${endDate}`;
   } else if (startDate) {
     submission_timestamp_date = `${startDate} to today`;

--- a/lib/lookerUtils.ts
+++ b/lib/lookerUtils.ts
@@ -25,23 +25,41 @@ export function getExperimentLookerDashboardDate(
 }
 
 /**
- * @returns the submission timestamp date filter to be used in the Looker dashboard links
+ * @param startDate The date that the Looker submission timestamp date filter
+ *        will start at if it's defined.
+ * @param endDate Either the calculated proposed end date or the actual end
+ *        date that the Looker submission timestamp date filter will end at
+ *        if it's defined. endDate should be one day ahead of the actual date
+ *        because Looker date filters don't include the end date.
+ * @param isCompleted True if the experiment is completed.
+ * @returns The submission timestamp date filter to be used in the Looker dashboard links.
  */
 export function getLookerSubmissionTimestampDateFilter(
   startDate?: string | null,
   endDate?: string | null,
   isCompleted?: boolean,
 ): string {
-  // Showing the last 30 complete days to ensure the dashboard isn't including today which has no data yet
-  let submission_timestamp_date = "30 day ago for 30 day";
-
-  if (!isCompleted && startDate && endDate && new Date() < new Date(endDate)) {
-    submission_timestamp_date = `${startDate} to ${endDate}`;
-  } else if (isCompleted && startDate && endDate) {
-    submission_timestamp_date = `${startDate} to ${endDate}`;
+  if (isCompleted && startDate && endDate) {
+    // This case covers completed experiments with defined startDate and
+    // endDate from the Experimenter API.
+    return `${startDate} to ${endDate}`;
+  } else if (
+    !isCompleted &&
+    startDate &&
+    endDate &&
+    new Date() < new Date(endDate)
+  ) {
+    // This case covers experiments that haven't reached their proposed end date.
+    return `${startDate} to ${endDate}`;
   } else if (startDate) {
-    submission_timestamp_date = `${startDate} to today`;
-  }
+    // This case covers experiments that are still ongoing past their proposed
+    // end date.
+    return `${startDate} to today`;
+  } else {
+    // This case covers any messages with undefined startDate and endDate.
 
-  return submission_timestamp_date;
+    // Showing the last 30 complete days to ensure the dashboard isn't
+    // including today which has no data yet.
+    return "30 day ago for 30 day";
+  }
 }

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -112,6 +112,8 @@ export function getDashboard(
   const encodedChannel = channel ? encodeURIComponent(channel) : "";
   const encodedExperiment = experiment ? encodeURIComponent(experiment) : "";
   const encodedBranchSlug = branchSlug ? encodeURIComponent(branchSlug) : "";
+  // The isCompleted value can be useful for messages that used to be in remote
+  // settings or old versions of Firefox.
   const encodedSubmissionDate = encodeURIComponent(
     getLookerSubmissionTimestampDateFilter(startDate, endDate, isCompleted),
   );

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -105,6 +105,7 @@ export function getDashboard(
   branchSlug?: string,
   startDate?: string | null,
   endDate?: string | null,
+  isCompleted?: boolean,
 ): string | undefined {
   const encodedMsgId = encodeURIComponent(msgId);
   const encodedTemplate = encodeURIComponent(template);
@@ -112,7 +113,7 @@ export function getDashboard(
   const encodedExperiment = experiment ? encodeURIComponent(experiment) : "";
   const encodedBranchSlug = branchSlug ? encodeURIComponent(branchSlug) : "";
   const encodedSubmissionDate = encodeURIComponent(
-    getLookerSubmissionTimestampDateFilter(startDate, endDate),
+    getLookerSubmissionTimestampDateFilter(startDate, endDate, isCompleted),
   );
   const dashboardId = getDashboardIdForTemplate(template);
 

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -50,6 +50,7 @@ function _branchInfoHasMicrosurvey(branchInfo: BranchInfo): boolean {
 
 type NimbusRecipeType = {
   _rawRecipe: NimbusExperiment;
+  _isCompleted: boolean;
 
   getRecipeInfo(): RecipeInfo;
   getRecipeOrBranchInfos(): RecipeOrBranchInfo[];
@@ -63,9 +64,11 @@ type NimbusRecipeType = {
 
 export class NimbusRecipe implements NimbusRecipeType {
   _rawRecipe;
+  _isCompleted;
 
-  constructor(recipe: NimbusExperiment) {
+  constructor(recipe: NimbusExperiment, isCompleted: boolean = false) {
     this._rawRecipe = recipe;
+    this._isCompleted = isCompleted;
   }
 
   /**
@@ -240,6 +243,12 @@ export class NimbusRecipe implements NimbusRecipeType {
       branchInfo.nimbusExperiment.startDate,
       branchInfo.nimbusExperiment.proposedDuration,
     );
+    let formattedEndDate;
+    if (branchInfo.nimbusExperiment.endDate) {
+      const endDate = new Date(branchInfo.nimbusExperiment.endDate);
+      endDate.setUTCDate(endDate.getUTCDate() + 1);
+      formattedEndDate = endDate.toISOString().slice(0, 10);
+    }
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,
       branchInfo.id,
@@ -247,7 +256,8 @@ export class NimbusRecipe implements NimbusRecipeType {
       branchInfo.nimbusExperiment.slug,
       branch.slug,
       branchInfo.nimbusExperiment.startDate,
-      proposedEndDate,
+      branchInfo.nimbusExperiment.endDate ? formattedEndDate : proposedEndDate,
+      this._isCompleted,
     );
     // if (!feature.value.content) {
     //   console.log("v.content is null");

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -10,6 +10,7 @@ import {
   getProposedEndDate,
   MESSAGING_EXPERIMENTS_DEFAULT_FEATURES,
   _substituteLocalizations,
+  formatDate,
 } from "../lib/experimentUtils.ts";
 import { getExperimentLookerDashboardDate } from "./lookerUtils.ts";
 
@@ -245,9 +246,7 @@ export class NimbusRecipe implements NimbusRecipeType {
     );
     let formattedEndDate;
     if (branchInfo.nimbusExperiment.endDate) {
-      const endDate = new Date(branchInfo.nimbusExperiment.endDate);
-      endDate.setUTCDate(endDate.getUTCDate() + 1);
-      formattedEndDate = endDate.toISOString().slice(0, 10);
+      formattedEndDate = formatDate(branchInfo.nimbusExperiment.endDate, 1);
     }
     branchInfo.ctrDashboardLink = getDashboard(
       branch.template,

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -68,7 +68,8 @@ export class NimbusRecipeCollection implements NimbusRecipeCollectionType {
 
     // console.log('returned experiments', experiments)
     this.recipes = experiments.map(
-      (nimbusExp: NimbusExperiment) => new NimbusRecipe(nimbusExp),
+      (nimbusExp: NimbusExperiment) =>
+        new NimbusRecipe(nimbusExp, this.isCompleted),
     );
 
     return this.recipes;


### PR DESCRIPTION
[Bug 1921080](https://bugzilla.mozilla.org/show_bug.cgi?id=1921080)

Changes made:
- Exposed dashboard links to completed rollouts and experiments
- Updated the dashboard date logic
    - The new logic is now to pass in an `isCompleted` parameter to the date calculation functions, and if the message is completed, the dashboard will show data from the startDate to the endDate. Otherwise with the old logic, completed messages would always show dashboards ranging from the startDate to today.