### PR TITLE
Bug 1889195 - Fix lower-case message id dashboard links

### DIFF
--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -84,7 +84,7 @@ describe("getDashboard", () => {
     const url = new URL(result);
     const params = url.searchParams;
 
-    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(url.pathname.endsWith(dashboardId)).toBe(true);
     expect(params.get("Messaging System Ping Type")).toBe(template);
     expect(params.get("Submission Date")).toBe(submissionDate);
     expect(params.get("Messaging System Message Id")).toBe(msgId);
@@ -103,8 +103,8 @@ describe("getDashboard", () => {
     const url = new URL(result);
     const params = url.searchParams;
 
-    expect(url.pathname.includes(dashboardId)).toBe(true);
-    expect(params.has("Submission Timestamp Date", submissionDate)).toBe(true);
+    expect(url.pathname.endsWith(dashboardId)).toBe(true);
+    expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
     expect(params.get("Message ID")).toBe(`%${msgId}%`);
     expect(params.get("Normalized Channel")).toBe("");
     expect(params.get("Experiment")).toBe("");
@@ -130,7 +130,7 @@ describe("getDashboard", () => {
     const url = new URL(result);
     const params = url.searchParams;
 
-    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(url.pathname.endsWith(dashboardId)).toBe(true);
     expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
     expect(params.get("Message ID")).toBe(`%${msgId}%`);
     expect(params.get("Normalized Channel")).toBe("");
@@ -158,7 +158,7 @@ describe("getDashboard", () => {
     const url = new URL(result);
     const params = url.searchParams;
 
-    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(url.pathname.endsWith(dashboardId)).toBe(true);
     expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
     expect(params.get("Message ID")).toBe(`%${msgId}%`);
     expect(params.get("Normalized Channel")).toBe("");
@@ -186,7 +186,7 @@ describe("getDashboard", () => {
     const url = new URL(result);
     const params = url.searchParams;
 
-    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(url.pathname.endsWith(dashboardId)).toBe(true);
     expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
     expect(params.get("Message ID")).toBe(`%${msgId}%`);
     expect(params.get("Normalized Channel")).toBe("");
@@ -213,7 +213,7 @@ describe("getDashboard", () => {
     const url = new URL(result);
     const params = url.searchParams;
 
-    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(url.pathname.endsWith(dashboardId)).toBe(true);
     expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
     expect(params.get("Message ID")).toBe(`%${msgId}%`);
     expect(params.get("Normalized Channel")).toBe("");

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -80,22 +80,17 @@ describe("getDashboard", () => {
       channel,
       experiment,
       branchSlug,
-    );
-    const resultUrl = new URL(result!);
-    const resultParams = new URLSearchParams(resultUrl.search);
+    ) as string;
+    const url = new URL(result);
+    const params = url.searchParams;
 
-    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
-    expect(resultParams.has("Messaging System Ping Type", template)).toBe(true);
-    expect(resultParams.has("Submission Date", submissionDate)).toBe(true);
-    expect(
-      resultParams.has(
-        "Messaging System Message Id",
-        `${msgId},` + `${msgId.toLowerCase()},` + `${msgId.toUpperCase()}`,
-      ),
-    ).toBe(true);
-    expect(resultParams.has("Normalized Channel", channel)).toBe(true);
-    expect(resultParams.has("Experiment", experiment)).toBe(true);
-    expect(resultParams.has("Experiment Branch", branchSlug)).toBe(true);
+    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(params.get("Messaging System Ping Type")).toBe(template);
+    expect(params.get("Submission Date")).toBe(submissionDate);
+    expect(params.get("Messaging System Message Id")).toBe(msgId);
+    expect(params.get("Normalized Channel")).toBe(channel);
+    expect(params.get("Experiment")).toBe(experiment);
+    expect(params.get("Experiment Branch")).toBe(branchSlug);
   });
 
   it("returns a correct featureCallout dashboard link", () => {
@@ -104,25 +99,16 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForTemplate(template);
     const submissionDate = "30 day ago for 30 day";
 
-    const result = getDashboard(template, msgId);
-    const resultUrl = new URL(result!);
-    const resultParams = new URLSearchParams(resultUrl.search);
+    const result = getDashboard(template, msgId) as string;
+    const url = new URL(result);
+    const params = url.searchParams;
 
-    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
-    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
-      true,
-    );
-    expect(
-      resultParams.has(
-        "Message ID",
-        `%${msgId}%,` +
-          `%${msgId.toLowerCase()}%,` +
-          `%${msgId.toUpperCase()}%`,
-      ),
-    ).toBe(true);
-    expect(resultParams.has("Normalized Channel", "")).toBe(true);
-    expect(resultParams.has("Experiment", "")).toBe(true);
-    expect(resultParams.has("Branch", "")).toBe(true);
+    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(params.has("Submission Timestamp Date", submissionDate)).toBe(true);
+    expect(params.get("Message ID")).toBe(`%${msgId}%`);
+    expect(params.get("Normalized Channel")).toBe("");
+    expect(params.get("Experiment")).toBe("");
+    expect(params.get("Branch")).toBe("");
   });
 
   // XXX should this be "about:welcome" to be consistent with featureIds?
@@ -140,25 +126,16 @@ describe("getDashboard", () => {
       undefined,
       experiment,
       branchSlug,
-    );
-    const resultUrl = new URL(result!);
-    const resultParams = new URLSearchParams(resultUrl.search);
+    ) as string;
+    const url = new URL(result);
+    const params = url.searchParams;
 
-    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
-    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
-      true,
-    );
-    expect(
-      resultParams.has(
-        "Message ID",
-        `%${msgId}%,` +
-          `%${msgId.toLowerCase()}%,` +
-          `%${msgId.toUpperCase()}%`,
-      ),
-    ).toBe(true);
-    expect(resultParams.has("Normalized Channel", "")).toBe(true);
-    expect(resultParams.has("Experiment", experiment)).toBe(true);
-    expect(resultParams.has("Branch", branchSlug)).toBe(true);
+    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
+    expect(params.get("Message ID")).toBe(`%${msgId}%`);
+    expect(params.get("Normalized Channel")).toBe("");
+    expect(params.get("Experiment")).toBe(experiment);
+    expect(params.get("Branch")).toBe(branchSlug);
   });
 
   it("returns a correct dashboard link with defined start and end dates where the end date is in the future", () => {
@@ -177,25 +154,16 @@ describe("getDashboard", () => {
       undefined,
       startDate,
       endDate,
-    );
-    const resultUrl = new URL(result!);
-    const resultParams = new URLSearchParams(resultUrl.search);
+    ) as string;
+    const url = new URL(result);
+    const params = url.searchParams;
 
-    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
-    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
-      true,
-    );
-    expect(
-      resultParams.has(
-        "Message ID",
-        `%${msgId}%,` +
-          `%${msgId.toLowerCase()}%,` +
-          `%${msgId.toUpperCase()}%`,
-      ),
-    ).toBe(true);
-    expect(resultParams.has("Normalized Channel", "")).toBe(true);
-    expect(resultParams.has("Experiment", "")).toBe(true);
-    expect(resultParams.has("Branch", "")).toBe(true);
+    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
+    expect(params.get("Message ID")).toBe(`%${msgId}%`);
+    expect(params.get("Normalized Channel")).toBe("");
+    expect(params.get("Experiment")).toBe("");
+    expect(params.get("Branch")).toBe("");
   });
 
   it("returns a correct dashboard link with defined start and end dates where the end date is in the past", () => {
@@ -214,25 +182,16 @@ describe("getDashboard", () => {
       undefined,
       startDate,
       endDate,
-    );
-    const resultUrl = new URL(result!);
-    const resultParams = new URLSearchParams(resultUrl.search);
+    ) as string;
+    const url = new URL(result);
+    const params = url.searchParams;
 
-    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
-    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
-      true,
-    );
-    expect(
-      resultParams.has(
-        "Message ID",
-        `%${msgId}%,` +
-          `%${msgId.toLowerCase()}%,` +
-          `%${msgId.toUpperCase()}%`,
-      ),
-    ).toBe(true);
-    expect(resultParams.has("Normalized Channel", "")).toBe(true);
-    expect(resultParams.has("Experiment", "")).toBe(true);
-    expect(resultParams.has("Branch", "")).toBe(true);
+    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
+    expect(params.get("Message ID")).toBe(`%${msgId}%`);
+    expect(params.get("Normalized Channel")).toBe("");
+    expect(params.get("Experiment")).toBe("");
+    expect(params.get("Branch")).toBe("");
   });
 
   it("returns a correct dashboard link with a defined start date", () => {
@@ -250,25 +209,16 @@ describe("getDashboard", () => {
       undefined,
       startDate,
       null,
-    );
-    const resultUrl = new URL(result!);
-    const resultParams = new URLSearchParams(resultUrl.search);
+    ) as string;
+    const url = new URL(result);
+    const params = url.searchParams;
 
-    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
-    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
-      true,
-    );
-    expect(
-      resultParams.has(
-        "Message ID",
-        `%${msgId}%,` +
-          `%${msgId.toLowerCase()}%,` +
-          `%${msgId.toUpperCase()}%`,
-      ),
-    ).toBe(true);
-    expect(resultParams.has("Normalized Channel", "")).toBe(true);
-    expect(resultParams.has("Experiment", "")).toBe(true);
-    expect(resultParams.has("Branch", "")).toBe(true);
+    expect(url.pathname.includes(dashboardId)).toBe(true);
+    expect(params.get("Submission Timestamp Date")).toBe(submissionDate);
+    expect(params.get("Message ID")).toBe(`%${msgId}%`);
+    expect(params.get("Normalized Channel")).toBe("");
+    expect(params.get("Experiment")).toBe("");
+    expect(params.get("Branch")).toBe("");
   });
 });
 

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -81,7 +81,7 @@ describe("getDashboard", () => {
       branchSlug,
     );
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30%20day%20ago%20for%2030%20day&Messaging+System+Message+Id=${encodeURIComponent(msgId)}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`;
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30%20day%20ago%20for%2030%20day&Messaging+System+Message+Id=${encodeURIComponent(msgId)}%2C+${encodeURIComponent(msgId).toLowerCase()}%2C+${encodeURIComponent(msgId).toUpperCase()}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`;
     expect(result).toEqual(expectedLink);
   });
 
@@ -90,7 +90,7 @@ describe("getDashboard", () => {
     const msgId = "1:23"; // weird chars to test URI encoding
     const dashboardId = getDashboardIdForTemplate(template);
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
 
     const result = getDashboard(template, msgId);
     expect(result).toEqual(expectedLink);
@@ -104,7 +104,7 @@ describe("getDashboard", () => {
     const branchSlug = "treatment:a";
     const dashboardId = getDashboardIdForTemplate(template);
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${encodeURIComponent(msgId.toUpperCase())}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`;
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`;
 
     const result = getDashboard(
       template,
@@ -123,7 +123,7 @@ describe("getDashboard", () => {
     const endDate = "2025-06-28";
     const dashboardId = getDashboardIdForTemplate(template);
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%202025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%202025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
 
     const result = getDashboard(
       template,
@@ -144,7 +144,7 @@ describe("getDashboard", () => {
     const endDate = "2024-05-28";
     const dashboardId = getDashboardIdForTemplate(template);
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%20today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%20today&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
 
     const result = getDashboard(
       template,
@@ -164,7 +164,7 @@ describe("getDashboard", () => {
     const startDate = "2024-03-08";
     const dashboardId = getDashboardIdForTemplate(template);
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%20today&Message+ID=%25${encodeURIComponent(msgId)}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%20today&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
 
     const result = getDashboard(
       template,

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -67,11 +67,12 @@ describe("toBinary", () => {
 describe("getDashboard", () => {
   it("returns a correct infobar dashboard link w/exp & branch", () => {
     const template = "infobar";
-    const msgId = "12`3"; // weird chars to test URI encoding
+    const msgId = "ab`c"; // weird chars to test URI encoding
     const channel = "release";
     const experiment = "experiment:test";
     const branchSlug = "treatment:a";
     const dashboardId = getDashboardIdForTemplate(template);
+    const submissionDate = "30 day ago for 30 day";
 
     const result = getDashboard(
       template,
@@ -80,31 +81,58 @@ describe("getDashboard", () => {
       experiment,
       branchSlug,
     );
+    const resultUrl = new URL(result!);
+    const resultParams = new URLSearchParams(resultUrl.search);
 
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodeURIComponent(template)}&Submission+Date=30%20day%20ago%20for%2030%20day&Messaging+System+Message+Id=${encodeURIComponent(msgId)}%2C+${encodeURIComponent(msgId).toLowerCase()}%2C+${encodeURIComponent(msgId).toUpperCase()}&Normalized+Channel=${encodeURIComponent(channel)}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodeURIComponent(experiment)}&Experiment+Branch=${encodeURIComponent(branchSlug)}`;
-    expect(result).toEqual(expectedLink);
+    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
+    expect(resultParams.has("Messaging System Ping Type", template)).toBe(true);
+    expect(resultParams.has("Submission Date", submissionDate)).toBe(true);
+    expect(
+      resultParams.has(
+        "Messaging System Message Id",
+        `${msgId},` + `${msgId.toLowerCase()},` + `${msgId.toUpperCase()}`,
+      ),
+    ).toBe(true);
+    expect(resultParams.has("Normalized Channel", channel)).toBe(true);
+    expect(resultParams.has("Experiment", experiment)).toBe(true);
+    expect(resultParams.has("Experiment Branch", branchSlug)).toBe(true);
   });
 
   it("returns a correct featureCallout dashboard link", () => {
     const template = "feature_callout";
-    const msgId = "1:23"; // weird chars to test URI encoding
+    const msgId = "a:bc"; // weird chars to test URI encoding
     const dashboardId = getDashboardIdForTemplate(template);
-
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const submissionDate = "30 day ago for 30 day";
 
     const result = getDashboard(template, msgId);
-    expect(result).toEqual(expectedLink);
+    const resultUrl = new URL(result!);
+    const resultParams = new URLSearchParams(resultUrl.search);
+
+    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
+    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
+      true,
+    );
+    expect(
+      resultParams.has(
+        "Message ID",
+        `%${msgId}%,` +
+          `%${msgId.toLowerCase()}%,` +
+          `%${msgId.toUpperCase()}%`,
+      ),
+    ).toBe(true);
+    expect(resultParams.has("Normalized Channel", "")).toBe(true);
+    expect(resultParams.has("Experiment", "")).toBe(true);
+    expect(resultParams.has("Branch", "")).toBe(true);
   });
 
   // XXX should this be "about:welcome" to be consistent with featureIds?
   it("returns a correct aboutwelcome dashboard link w/exp & branch", () => {
     const template = "aboutwelcome";
-    const msgId = "1:23"; // weird chars to test URI encoding
+    const msgId = "a:bc"; // weird chars to test URI encoding
     const experiment = "experiment:test";
     const branchSlug = "treatment:a";
     const dashboardId = getDashboardIdForTemplate(template);
-
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=${encodeURIComponent(experiment)}&Branch=${encodeURIComponent(branchSlug)}`;
+    const submissionDate = "30 day ago for 30 day";
 
     const result = getDashboard(
       template,
@@ -113,17 +141,33 @@ describe("getDashboard", () => {
       experiment,
       branchSlug,
     );
-    expect(result).toEqual(expectedLink);
+    const resultUrl = new URL(result!);
+    const resultParams = new URLSearchParams(resultUrl.search);
+
+    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
+    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
+      true,
+    );
+    expect(
+      resultParams.has(
+        "Message ID",
+        `%${msgId}%,` +
+          `%${msgId.toLowerCase()}%,` +
+          `%${msgId.toUpperCase()}%`,
+      ),
+    ).toBe(true);
+    expect(resultParams.has("Normalized Channel", "")).toBe(true);
+    expect(resultParams.has("Experiment", experiment)).toBe(true);
+    expect(resultParams.has("Branch", branchSlug)).toBe(true);
   });
 
   it("returns a correct dashboard link with defined start and end dates where the end date is in the future", () => {
     const template = "feature_callout";
-    const msgId = "1:23"; // weird chars to test URI encoding
+    const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
     const endDate = "2025-06-28";
     const dashboardId = getDashboardIdForTemplate(template);
-
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%202025-06-28&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const submissionDate = "2024-03-08 to 2025-06-28";
 
     const result = getDashboard(
       template,
@@ -134,17 +178,33 @@ describe("getDashboard", () => {
       startDate,
       endDate,
     );
-    expect(result).toEqual(expectedLink);
+    const resultUrl = new URL(result!);
+    const resultParams = new URLSearchParams(resultUrl.search);
+
+    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
+    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
+      true,
+    );
+    expect(
+      resultParams.has(
+        "Message ID",
+        `%${msgId}%,` +
+          `%${msgId.toLowerCase()}%,` +
+          `%${msgId.toUpperCase()}%`,
+      ),
+    ).toBe(true);
+    expect(resultParams.has("Normalized Channel", "")).toBe(true);
+    expect(resultParams.has("Experiment", "")).toBe(true);
+    expect(resultParams.has("Branch", "")).toBe(true);
   });
 
   it("returns a correct dashboard link with defined start and end dates where the end date is in the past", () => {
     const template = "feature_callout";
-    const msgId = "1:23"; // weird chars to test URI encoding
+    const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
     const endDate = "2024-05-28";
     const dashboardId = getDashboardIdForTemplate(template);
-
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%20today&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const submissionDate = "2024-03-08 to today";
 
     const result = getDashboard(
       template,
@@ -155,16 +215,32 @@ describe("getDashboard", () => {
       startDate,
       endDate,
     );
-    expect(result).toEqual(expectedLink);
+    const resultUrl = new URL(result!);
+    const resultParams = new URLSearchParams(resultUrl.search);
+
+    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
+    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
+      true,
+    );
+    expect(
+      resultParams.has(
+        "Message ID",
+        `%${msgId}%,` +
+          `%${msgId.toLowerCase()}%,` +
+          `%${msgId.toUpperCase()}%`,
+      ),
+    ).toBe(true);
+    expect(resultParams.has("Normalized Channel", "")).toBe(true);
+    expect(resultParams.has("Experiment", "")).toBe(true);
+    expect(resultParams.has("Branch", "")).toBe(true);
   });
 
   it("returns a correct dashboard link with a defined start date", () => {
     const template = "feature_callout";
-    const msgId = "1:23"; // weird chars to test URI encoding
+    const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
     const dashboardId = getDashboardIdForTemplate(template);
-
-    const expectedLink = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=2024-03-08%20to%20today&Message+ID=%25${encodeURIComponent(msgId)}%25%2C+%25${encodeURIComponent(msgId).toLowerCase()}%25%2C+%25${encodeURIComponent(msgId).toUpperCase()}%25&Normalized+Channel=&Experiment=&Branch=`;
+    const submissionDate = "2024-03-08 to today";
 
     const result = getDashboard(
       template,
@@ -175,7 +251,24 @@ describe("getDashboard", () => {
       startDate,
       null,
     );
-    expect(result).toEqual(expectedLink);
+    const resultUrl = new URL(result!);
+    const resultParams = new URLSearchParams(resultUrl.search);
+
+    expect(resultUrl.pathname.includes(dashboardId)).toBe(true);
+    expect(resultParams.has("Submission Timestamp Date", submissionDate)).toBe(
+      true,
+    );
+    expect(
+      resultParams.has(
+        "Message ID",
+        `%${msgId}%,` +
+          `%${msgId.toLowerCase()}%,` +
+          `%${msgId.toUpperCase()}%`,
+      ),
+    ).toBe(true);
+    expect(resultParams.has("Normalized Channel", "")).toBe(true);
+    expect(resultParams.has("Experiment", "")).toBe(true);
+    expect(resultParams.has("Branch", "")).toBe(true);
   });
 });
 

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -1,7 +1,9 @@
 import { NimbusRecipe } from "@/lib/nimbusRecipe";
 import { ExperimentFakes } from "@/__tests__/ExperimentFakes.mjs";
 import { BranchInfo } from "@/app/columns.jsx";
-import { getDashboardIdForTemplate } from "@/lib/messageUtils";
+import { getDashboard, getDashboardIdForTemplate } from "@/lib/messageUtils";
+import { getExperimentLookerDashboardDate } from "@/lib/lookerUtils";
+import { formatDate } from "@/lib/experimentUtils";
 
 //XXX We're passing this custom object for about:welcome, since ExperimentFakes
 // doesn't quite give us what we want in that case. We probably want to tweak
@@ -136,14 +138,34 @@ describe("NimbusRecipe", () => {
       const branch = AW_RECIPE.branches[1];
 
       const branchInfo = nimbusRecipe.getBranchInfo(branch);
-      const dashboardId = getDashboardIdForTemplate("aboutwelcome");
+      const proposedEndDate = getExperimentLookerDashboardDate(
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.proposedDuration,
+      );
+      const formattedEndDate = formatDate(
+        branchInfo.nimbusExperiment.endDate as string,
+        1,
+      );
+
+      const dashboardLink = getDashboard(
+        branchInfo.template as string,
+        branchInfo.id,
+        undefined,
+        branchInfo.nimbusExperiment.slug,
+        branch.slug,
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.endDate
+          ? formattedEndDate
+          : proposedEndDate,
+        false, // default for isCompleted in constructor
+      );
 
       // XXX getBranchInfo is actually going to return a previewLink, which
       // makes this test kind of brittle. We could refactor this to no longer
       // use deepEqual and check for the existence of object properties instead.
       expect(branchInfo).toEqual({
         product: "Desktop",
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25feature_value_id%3Atreatment-a%25%2C+%25${"feature_value_id%3Atreatment-a".toLowerCase()}%25%2C+%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: dashboardLink,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE,
@@ -171,11 +193,31 @@ describe("NimbusRecipe", () => {
       const branch = AW_RECIPE_NO_SCREENS.branches[1];
 
       const branchInfo = nimbusRecipe.getBranchInfo(branch);
-      const dashboardId = getDashboardIdForTemplate("aboutwelcome");
+      const proposedEndDate = getExperimentLookerDashboardDate(
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.proposedDuration,
+      );
+      const formattedEndDate = formatDate(
+        branchInfo.nimbusExperiment.endDate as string,
+        1,
+      );
+
+      const dashboardLink = getDashboard(
+        branchInfo.template as string,
+        branchInfo.id,
+        undefined,
+        branchInfo.nimbusExperiment.slug,
+        branch.slug,
+        branchInfo.nimbusExperiment.startDate,
+        branchInfo.nimbusExperiment.endDate
+          ? formattedEndDate
+          : proposedEndDate,
+        false, // default for isCompleted in constructor
+      );
 
       expect(branchInfo).toEqual({
         product: "Desktop",
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25feature_value_id%3Atreatment-a%25%2C+%25${"feature_value_id%3Atreatment-a".toLowerCase()}%25%2C+%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: dashboardLink,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE_NO_SCREENS,

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -143,7 +143,7 @@ describe("NimbusRecipe", () => {
       // use deepEqual and check for the existence of object properties instead.
       expect(branchInfo).toEqual({
         product: "Desktop",
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25feature_value_id%3Atreatment-a%25%2C+%25${"feature_value_id%3Atreatment-a".toLowerCase()}%25%2C+%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE,
@@ -175,7 +175,7 @@ describe("NimbusRecipe", () => {
 
       expect(branchInfo).toEqual({
         product: "Desktop",
-        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25FEATURE_VALUE_ID%3ATREATMENT-A%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
+        ctrDashboardLink: `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=30%20day%20ago%20for%2030%20day&Message+ID=%25feature_value_id%3Atreatment-a%25%2C+%25${"feature_value_id%3Atreatment-a".toLowerCase()}%25%2C+%25${"feature_value_id%3Atreatment-a".toUpperCase()}%25&Normalized+Channel=&Experiment=aboutwelcome-test-recipe&Branch=treatment-a`,
         id: "feature_value_id:treatment-a",
         isBranch: true,
         nimbusExperiment: AW_RECIPE_NO_SCREENS,

--- a/lib/asrouter-local-prod-messages/data.json
+++ b/lib/asrouter-local-prod-messages/data.json
@@ -774,7 +774,7 @@
   },
   {
     "weight": 100,
-    "id": "INFOBAR_LAUNCH_ON_LOGIN",
+    "id": "infobar_launch_on_login",
     "groups": ["cfr"],
     "template": "infobar",
     "content": {
@@ -1980,7 +1980,7 @@
     "provider": "onboarding"
   },
   {
-    "id": "MR_WELCOME_DEFAULT",
+    "id": "mr_welcome_default",
     "template": "defaultaboutwelcome",
     "transitions": true,
     "backdrop": "var(--mr-welcome-background-color) var(--mr-welcome-background-gradient)",

--- a/lib/asrouter-local-prod-messages/data.json
+++ b/lib/asrouter-local-prod-messages/data.json
@@ -774,7 +774,7 @@
   },
   {
     "weight": 100,
-    "id": "infobar_launch_on_login",
+    "id": "INFOBAR_LAUNCH_ON_LOGIN",
     "groups": ["cfr"],
     "template": "infobar",
     "content": {
@@ -1980,7 +1980,7 @@
     "provider": "onboarding"
   },
   {
-    "id": "mr_welcome_default",
+    "id": "MR_WELCOME_DEFAULT",
     "template": "defaultaboutwelcome",
     "transitions": true,
     "backdrop": "var(--mr-welcome-background-color) var(--mr-welcome-background-gradient)",

--- a/lib/experimentUtils.ts
+++ b/lib/experimentUtils.ts
@@ -42,10 +42,7 @@ export const MESSAGING_EXPERIMENTS_DEFAULT_FEATURES: string[] = [
  *
  * XXX Until we fix the upcase bug, we'll be hiding these dashboards.
  */
-export const HIDE_DASHBOARD_EXPERIMENTS: string[] = [
-  "recommend-media-addons-feature-existing-users",
-  "recommend-media-addons-feature-callout",
-];
+export const HIDE_DASHBOARD_EXPERIMENTS: string[] = [];
 
 /**
  *

--- a/lib/experimentUtils.ts
+++ b/lib/experimentUtils.ts
@@ -37,10 +37,8 @@ export const MESSAGING_EXPERIMENTS_DEFAULT_FEATURES: string[] = [
 ];
 
 /**
- * These are experiment with dashboard links that are currently (incorrectly
- * empty).
- *
- * XXX Until we fix the upcase bug, we'll be hiding these dashboards.
+ * If we have experiment dashboards with serious problems, we can hide those
+ * dashboards by adding the experiment slugs to this array.
  */
 export const HIDE_DASHBOARD_EXPERIMENTS: string[] = [];
 

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -44,10 +44,19 @@ export async function runLookQuery(lookId: string): Promise<string> {
   return results;
 }
 
+/**
+ * 
+ * @param template the message template
+ * @param filters an object containing any filters used in the Looker query (eg. channel, templates, experiment, branch)
+ * @param filter_expression filter data with "or" conditions
+ * @param startDate the experiment start date
+ * @param endDate the experiment proposed end date
+ * @returns the result of the query that is created by the given filters and filter_expression, and the appropriate template and submission timestamp
+ */
 export async function runQueryForTemplate(
   template: string,
   filters: any,
-  filter_expression?: any,
+  filter_expression?: string,
   startDate?: string | null,
   endDate?: string | null,
 ): Promise<any> {
@@ -116,7 +125,8 @@ export async function getCTRPercentData(
 ): Promise<CTRData | undefined> {
   // XXX the filters are currently defined to match the filters in getDashboard.
   // It would be more ideal to consider a different approach when definining
-  // those filters to sync up the data in both places.
+  // those filters to sync up the data in both places. Non-trivial changes to
+  // this code are worth applying some manual performance checking.
   let queryResult;
   if (template === "infobar") {
     queryResult = await runQueryForTemplate(

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -45,13 +45,8 @@ export async function runLookQuery(lookId: string): Promise<string> {
 }
 
 /**
- * Currently, we use the filter_expression so that we can add an OR condition
- * for the message id to check for the original casing, lower casing, and
- * upper casing. See the `getCTRPercentData` function for an example of the
- * filter_expression.
  * @param template the message template
  * @param filters an object containing any filters used in the Looker query (eg. channel, templates, experiment, branch)
- * @param filter_expression filter data with "or" conditions
  * @param startDate the experiment start date
  * @param endDate the experiment proposed end date
  * @returns the result of the query that is created by the given filters and filter_expression, and the appropriate template and submission timestamp
@@ -59,7 +54,6 @@ export async function runLookQuery(lookId: string): Promise<string> {
 export async function runQueryForTemplate(
   template: string,
   filters: any,
-  filter_expression?: string,
   startDate?: string | null,
   endDate?: string | null,
 ): Promise<any> {
@@ -92,7 +86,6 @@ export async function runQueryForTemplate(
       filters,
     );
   }
-  newQueryBody.filter_expression = filter_expression;
 
   const newQuery = await SDK.ok(SDK.create_query(newQueryBody));
   const result = await SDK.ok(
@@ -141,13 +134,6 @@ export async function getCTRPercentData(
         "messaging_system__ping_info__experiments.key": experiment,
         "messaging_system__ping_info__experiments.value__branch": branch,
       },
-      "matches_filter(${messaging_system.metrics__text2__messaging_system_message_id}, `" +
-        id +
-        "`) OR matches_filter(${messaging_system.metrics__text2__messaging_system_message_id}, `" +
-        id.toUpperCase() +
-        "`) OR matches_filter(${messaging_system.metrics__text2__messaging_system_message_id}, `" +
-        id.toLowerCase() +
-        "`)",
       startDate,
       endDate,
     );
@@ -159,13 +145,6 @@ export async function getCTRPercentData(
         "onboarding_v1__experiments.experiment": experiment,
         "onboarding_v1__experiments.branch": branch,
       },
-      "(matches_filter(${event_counts.message_id}, `%" +
-        id +
-        "%`) OR matches_filter(${event_counts.message_id}, `%" +
-        id.toUpperCase() +
-        "%`) OR matches_filter(${event_counts.message_id}, `%" +
-        id.toLowerCase() +
-        "%`)) AND matches_filter(${event_counts.message_id}, `%^_0^_%`)",
       startDate,
       endDate,
     );

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -45,7 +45,10 @@ export async function runLookQuery(lookId: string): Promise<string> {
 }
 
 /**
- * 
+ * Currently, we use the filter_expression so that we can add an OR condition
+ * for the message id to check for the original casing, lower casing, and
+ * upper casing. See the `getCTRPercentData` function for an example of the
+ * filter_expression.
  * @param template the message template
  * @param filters an object containing any filters used in the Looker query (eg. channel, templates, experiment, branch)
  * @param filter_expression filter data with "or" conditions

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -128,6 +128,7 @@ export async function getCTRPercentData(
     queryResult = await runQueryForTemplate(
       template,
       {
+        "messaging_system.metrics__text2__messaging_system_message_id": id,
         "messaging_system.normalized_channel": channel,
         "messaging_system.metrics__string__messaging_system_ping_type":
           template,
@@ -141,6 +142,7 @@ export async function getCTRPercentData(
     queryResult = await runQueryForTemplate(
       template,
       {
+        "event_counts.message_id": "%" + id + "%",
         "event_counts.normalized_channel": channel,
         "onboarding_v1__experiments.experiment": experiment,
         "onboarding_v1__experiments.branch": branch,

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -132,7 +132,7 @@ export function getDashboard(
   const dashboardId = getDashboardIdForTemplate(template);
 
   if (_isAboutWelcomeTemplate(template)) {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId?.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`;
   }
 
   if (template === "infobar") {

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -131,12 +131,20 @@ export function getDashboard(
   );
   const dashboardId = getDashboardIdForTemplate(template);
 
+  let baseUrl = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}`;
+
   if (_isAboutWelcomeTemplate(template)) {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId}%25%2C+%25${encodedMsgId.toLowerCase()}%25%2C+%25${encodedMsgId.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`;
+    return new URL(
+      `?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId}%25%2C+%25${encodedMsgId.toLowerCase()}%25%2C+%25${encodedMsgId.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`,
+      baseUrl,
+    ).toString();
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=${encodedSubmissionDate}&Messaging+System+Message+Id=${encodedMsgId}%2C+${encodedMsgId.toLowerCase()}%2C+${encodedMsgId.toUpperCase()}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
+    return new URL(
+      `?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=${encodedSubmissionDate}&Messaging+System+Message+Id=${encodedMsgId}%2C+${encodedMsgId.toLowerCase()}%2C+${encodedMsgId.toUpperCase()}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`,
+      baseUrl,
+    ).toString();
   }
 
   return undefined;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -132,11 +132,11 @@ export function getDashboard(
   const dashboardId = getDashboardIdForTemplate(template);
 
   if (_isAboutWelcomeTemplate(template)) {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Submission+Timestamp+Date=${encodedSubmissionDate}&Message+ID=%25${encodedMsgId}%25%2C+%25${encodedMsgId.toLowerCase()}%25%2C+%25${encodedMsgId.toUpperCase()}%25&Normalized+Channel=${encodedChannel}&Experiment=${encodedExperiment}&Branch=${encodedBranchSlug}`;
   }
 
   if (template === "infobar") {
-    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=${encodedSubmissionDate}&Messaging+System+Message+Id=${encodedMsgId}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
+    return `https://mozilla.cloud.looker.com/dashboards/${dashboardId}?Messaging+System+Ping+Type=${encodedTemplate}&Submission+Date=${encodedSubmissionDate}&Messaging+System+Message+Id=${encodedMsgId}%2C+${encodedMsgId.toLowerCase()}%2C+${encodedMsgId.toUpperCase()}&Normalized+Channel=${encodedChannel}&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=${encodedExperiment}&Experiment+Branch=${encodedBranchSlug}`;
   }
 
   return undefined;

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -131,11 +131,9 @@ export function getDashboard(
   let paramObj;
 
   if (_isAboutWelcomeTemplate(template)) {
-    const multiCaseMessageIds =
-      `%${msgId}%,` + `%${msgId.toLowerCase()}%,` + `%${msgId.toUpperCase()}%`;
     paramObj = {
       "Submission Timestamp Date": submissionDate,
-      "Message ID": multiCaseMessageIds,
+      "Message ID": `%${msgId}%`,
       "Normalized Channel": channel ? channel : "",
       Experiment: experiment ? experiment : "",
       Branch: branchSlug ? branchSlug : "",
@@ -143,12 +141,10 @@ export function getDashboard(
   }
 
   if (template === "infobar") {
-    const multiCaseMessageIds =
-      `${msgId},` + `${msgId.toLowerCase()},` + `${msgId.toUpperCase()}`;
     paramObj = {
       "Messaging System Ping Type": template,
       "Submission Date": submissionDate,
-      "Messaging System Message Id": multiCaseMessageIds,
+      "Messaging System Message Id": msgId,
       "Normalized Channel": channel ? channel : "",
       "Normalized OS": "",
       "Client Info App Display Version": "",

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -27,7 +27,7 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
         // We are making all branch ids upper case to make up for
         // Looker being case sensitive
         const ctrPercentData = await getCTRPercentData(
-          branchInfo.id.toUpperCase(),
+          branchInfo.id,
           branchInfo.template!,
           undefined,
           branchInfo.nimbusExperiment.slug,


### PR DESCRIPTION
I found out that Looker filters can include OR statements so I tried updating logic so the message ID filters could catch the original ID, lower cased ID, and upper cased ID in all their filters for the dashboard links and CTR metrics. This would ensure that we don't always upper case all IDs and miss any message IDs that are lower case in the telemetry, without having to update anything in the dashboard LookMLs. I have this draft PR up for any initial feedback before I go in to clean up the tests.