### PR TITLE
Keep non-msg aboutwelcome features from crashing

### DIFF
--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -164,6 +164,7 @@ describe("NimbusRecipe", () => {
       const AW_RECIPE_NO_SCREENS = JSON.parse(JSON.stringify(AW_RECIPE));
       AW_RECIPE_NO_SCREENS.branches[1].features[0].value = {
         id: "feature_value_id:treatment-a",
+        backdrop: "XXX-no-msg-test-hack-deleteme-see-getBranchInfo",
       };
 
       const nimbusRecipe = new NimbusRecipe(AW_RECIPE_NO_SCREENS);

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -99,6 +99,15 @@ export class NimbusRecipe implements NimbusRecipeType {
     // a surface to it.
     let template;
     if (feature.featureId === "aboutwelcome" && branch.slug != "control") {
+      // XXXdmose nasty hack to prevent what I'm calling
+      // "non-messaging-aboutwelcome" features from breaking
+      // Skylight completely. Need to talk to Jason and Meg to
+      // understand more details and figure out what to do here...
+      if (Object.keys(feature.value).length <= 1) {
+        branchInfo.template = branch.template = "non-messaging-aboutwelcome";
+        return branchInfo;
+      }
+
       template = "aboutwelcome";
     } else if (
       feature.featureId === "whatsNewPage" &&


### PR DESCRIPTION
Make live Skylight instance update again by adding a bandaid so that we don't blow up on "non-msg about:welcome" feature values.  Need to talk to Meg and Jason and device something better.  No review.