### PR TITLE
Revert "Bump @types/node from 22.10.1 to 22.10.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2905,9 +2905,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This reverts commit b76028cf385e093b8da7158bf0f0ab3672ad1de2.  That change triggered a crash in the typescript compiler during CI that won't be fixed until TypeScript 5.7.3.  This should fix the "red" status of `main` in CI.