### PR TITLE
Bug 1891121 - Add experiment brief links to experiment and rollout tables

### DIFF
--- a/__tests__/lib/experimentUtils.test.ts
+++ b/__tests__/lib/experimentUtils.test.ts
@@ -3,9 +3,6 @@ import {
   _substituteLocalizations,
 } from "../../lib/experimentUtils.ts";
 
-import { types } from "@mozilla/nimbus-shared";
-type NimbusExperiment = types.experiments.NimbusExperiment;
-
 const LOCALIZATIONS = {
   foo: "localized foo text",
   qux: "localized qux text",

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -363,4 +363,59 @@ describe("NimbusRecipe", () => {
       );
     });
   });
+
+  describe("getExperimentBriefLink", () => {
+    it("returns the correct experiment brief link", () => {
+      const documentationLinks = [
+        {
+          title: "DESIGN_DOC",
+          link: "https://docs.google.com/document/d/1mKXnU-qbStb1OUNHmDOQY5Awb-Wz5e8wit28jkUKP-4/edit#heading=h.uoblsnu302hk",
+        },
+        {
+          title: "ENG_TICKET",
+          link: "https://mozilla-hub.atlassian.net/browse/OMC-811",
+        },
+        {
+          title: "DESIGN_DOC",
+          link: "https://www.figma.com/design/V2alIUZh1C4UXoWacJjZCA/Bookmarks-improvements?node-id=2073-16689&node-type=canvas&t=yXRpQavvJl25GGbF-0",
+        },
+      ];
+      const rawRecipe = ExperimentFakes.recipe("test-recipe");
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
+
+      const result = nimbusRecipe.getExperimentBriefLink(documentationLinks);
+
+      expect(result).toBe(
+        "https://docs.google.com/document/d/1mKXnU-qbStb1OUNHmDOQY5Awb-Wz5e8wit28jkUKP-4/edit#heading=h.uoblsnu302hk",
+      );
+    });
+
+    it("returns undefined if no experiment brief document exists", () => {
+      const documentationLinks = [
+        {
+          title: "DS_JIRA",
+          link: "https://mozilla-hub.atlassian.net/browse/DS-3819",
+        },
+        {
+          title: "ENG_TICKET",
+          link: "https://mozilla-hub.atlassian.net/browse/FXE-952",
+        },
+      ];
+      const rawRecipe = ExperimentFakes.recipe("test-recipe");
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
+
+      const result = nimbusRecipe.getExperimentBriefLink(documentationLinks);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  it("returns undefined if no documentation link exists", () => {
+    const rawRecipe = ExperimentFakes.recipe("test-recipe");
+    const nimbusRecipe = new NimbusRecipe(rawRecipe);
+
+    const result = nimbusRecipe.getExperimentBriefLink(undefined);
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -3,11 +3,22 @@ import { types } from "@mozilla/nimbus-shared";
 import { ColumnDef, Row } from "@tanstack/react-table";
 import { NimbusRecipe } from "@/lib/nimbusRecipe";
 import { PreviewLinkButton } from "@/components/ui/previewlinkbutton";
-import { ChevronsUpDown, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  ChevronsUpDown,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+} from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import { InfoPopover } from "@/components/ui/infopopover";
 import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
 import { HIDE_DASHBOARD_EXPERIMENTS } from "@/lib/experimentUtils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function SurfaceTag(template: string, surface: string) {
   const { tagColor, docs } = getSurfaceDataForTemplate(template);
@@ -98,6 +109,7 @@ export type RecipeInfo = {
   isBranch?: boolean;
   branches: BranchInfo[]; // XXX rename this to branchInfos to avoid confusion with the branches property inside NimbusExperiment
   hasMicrosurvey?: boolean;
+  experimentBriefLink?: string;
 };
 
 export type BranchInfo = {
@@ -169,10 +181,32 @@ const previewURLInfoButton = (
 );
 
 const microsurveyBadge = (
-  <div className="inline ml-1 px-2 py-1 bg-slate-300 text-foreground text-3xs rounded-md font-medium">
+  <div className="inline px-2 py-1 bg-slate-300 text-foreground text-3xs rounded-md font-medium">
     Microsurvey
   </div>
 );
+
+function experimentBriefTooltip(link: string) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <a
+            className="flex items-center justify-center rounded-md text-primary hover:text-primary/80 visited:text-inherit"
+            href={link}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <FileText size={14} />
+          </a>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>See experiment brief</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 function filterBySurface(
   row: Row<RecipeOrBranchInfo>,
@@ -370,32 +404,36 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <>
-            <a
-              href={props.row.original.experimenterLink}
-              className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {props.row.original.userFacingName || props.row.original.id}
-              <svg
-                fill="currentColor"
-                fillOpacity="0.6"
-                viewBox="0 0 8 8"
-                className="inline h-[1.2rem] w-[1.2rem] px-1"
-                aria-hidden="true"
-                style={{
-                  marginInline: "0.1rem 0",
-                  paddingBlock: "0 0.1rem",
-                  overflow: "visible",
-                }}
+          <div>
+            <div className="flex flex-row gap-x-2 items-center">
+              {props.row.original.experimentBriefLink &&
+                experimentBriefTooltip(props.row.original.experimentBriefLink)}
+              {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
+              <a
+                href={props.row.original.experimenterLink}
+                className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
+                target="_blank"
+                rel="noreferrer"
               >
-                <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
-              </svg>
-            </a>
-            {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
+                {props.row.original.userFacingName || props.row.original.id}
+                <svg
+                  fill="currentColor"
+                  fillOpacity="0.6"
+                  viewBox="0 0 8 8"
+                  className="inline h-[1.2rem] w-[1.2rem] px-1"
+                  aria-hidden="true"
+                  style={{
+                    marginInline: "0.1rem 0",
+                    paddingBlock: "0 0.1rem",
+                    overflow: "visible",
+                  }}
+                >
+                  <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
+                </svg>
+              </a>
+            </div>
             <div className="font-mono text-3xs">{props.row.original.id}</div>
-          </>
+          </div>
         );
       }
 
@@ -571,32 +609,36 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <>
-            <a
-              href={props.row.original.experimenterLink}
-              className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {props.row.original.userFacingName || props.row.original.id}
-              <svg
-                fill="currentColor"
-                fillOpacity="0.6"
-                viewBox="0 0 8 8"
-                className="inline h-[1.2rem] w-[1.2rem] px-1"
-                aria-hidden="true"
-                style={{
-                  marginInline: "0.1rem 0",
-                  paddingBlock: "0 0.1rem",
-                  overflow: "visible",
-                }}
+          <div>
+            <div className="flex flex-row gap-x-2 items-center">
+              {props.row.original.experimentBriefLink &&
+                experimentBriefTooltip(props.row.original.experimentBriefLink)}
+              {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
+              <a
+                href={props.row.original.experimenterLink}
+                className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
+                target="_blank"
+                rel="noreferrer"
               >
-                <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
-              </svg>
-            </a>
-            {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
+                {props.row.original.userFacingName || props.row.original.id}
+                <svg
+                  fill="currentColor"
+                  fillOpacity="0.6"
+                  viewBox="0 0 8 8"
+                  className="inline h-[1.2rem] w-[1.2rem] px-1"
+                  aria-hidden="true"
+                  style={{
+                    marginInline: "0.1rem 0",
+                    paddingBlock: "0 0.1rem",
+                    overflow: "visible",
+                  }}
+                >
+                  <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
+                </svg>
+              </a>
+            </div>
             <div className="font-mono text-3xs">{props.row.original.id}</div>
-          </>
+          </div>
         );
       }
 

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -404,18 +404,19 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <div>
-            <div className="flex flex-row gap-x-2 items-center">
-              {props.row.original.experimentBriefLink &&
-                experimentBriefTooltip(props.row.original.experimentBriefLink)}
-              {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
+          <div className="flex flex-row gap-x-2 items-center">
+            {props.row.original.experimentBriefLink &&
+              experimentBriefTooltip(props.row.original.experimentBriefLink)}
+            <div className="flex flex-col gap-y-1 w-[24rem] overflow-visible">
               <a
                 href={props.row.original.experimenterLink}
-                className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
+                className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline whitespace-nowrap"
                 target="_blank"
                 rel="noreferrer"
               >
+                {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
                 {props.row.original.userFacingName || props.row.original.id}
+                {/* XXX switch to a Lucide icon for external link */}
                 <svg
                   fill="currentColor"
                   fillOpacity="0.6"
@@ -431,8 +432,8 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
                   <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
                 </svg>
               </a>
+              <div className="font-mono text-3xs">{props.row.original.id}</div>
             </div>
-            <div className="font-mono text-3xs">{props.row.original.id}</div>
           </div>
         );
       }
@@ -440,7 +441,7 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
       const recipe = new NimbusRecipe(props.row.original.nimbusExperiment);
 
       return (
-        <div className="ps-6">
+        <div className="ps-14">
           <a
             href={recipe.getBranchRecipeLink(props.row.original.slug)}
             className="text-xs text-primary visited:text-inherit hover:text-blue-800 no-underline"
@@ -448,6 +449,7 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
             rel="noreferrer"
           >
             {props.row.original.description || props.row.original.id}
+            {/* XXX switch to a Lucide icon for external link */}
             <svg
               fill="currentColor"
               fillOpacity="0.6"
@@ -621,6 +623,7 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
                 rel="noreferrer"
               >
                 {props.row.original.userFacingName || props.row.original.id}
+                {/* XXX switch to a Lucide icon for external link */}
                 <svg
                   fill="currentColor"
                   fillOpacity="0.6"
@@ -653,6 +656,7 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
             rel="noreferrer"
           >
             {props.row.original.description || props.row.original.id}
+            {/* XXX switch to a Lucide icon for external link */}
             <svg
               fill="currentColor"
               fillOpacity="0.6"

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -404,13 +404,13 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <div className="flex flex-row gap-x-2 items-center">
+          <div className="flex flex-row gap-x-2 items-start">
             {props.row.original.experimentBriefLink &&
               experimentBriefTooltip(props.row.original.experimentBriefLink)}
             <div className="flex flex-col gap-y-1 w-[24rem] overflow-visible">
               <a
                 href={props.row.original.experimenterLink}
-                className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline whitespace-nowrap"
+                className="font-semibold text-sm flex flex-row items-center gap-x-1 text-primary visited:text-inherit hover:text-blue-800 no-underline whitespace-nowrap"
                 target="_blank"
                 rel="noreferrer"
               >
@@ -421,7 +421,7 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
                   fill="currentColor"
                   fillOpacity="0.6"
                   viewBox="0 0 8 8"
-                  className="inline h-[1.2rem] w-[1.2rem] px-1"
+                  className="inline h-3 w-3"
                   aria-hidden="true"
                   style={{
                     marginInline: "0.1rem 0",

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { types } from "@mozilla/nimbus-shared";
 import { ColumnDef, Row } from "@tanstack/react-table";
 import { NimbusRecipe } from "@/lib/nimbusRecipe";
 import { PreviewLinkButton } from "@/components/ui/previewlinkbutton";
@@ -88,7 +87,6 @@ export type FxMSMessageInfo = {
   hidePreview?: boolean;
 };
 
-// type NimbusExperiment = types.experiments.NimbusExperiment;
 const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
 type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
 

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -88,7 +88,9 @@ export type FxMSMessageInfo = {
   hidePreview?: boolean;
 };
 
-type NimbusExperiment = types.experiments.NimbusExperiment;
+// type NimbusExperiment = types.experiments.NimbusExperiment;
+const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
+type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
 
 export type RecipeInfo = {
   product: "Desktop" | "Android";
@@ -192,7 +194,7 @@ function experimentBriefTooltip(link: string) {
       <Tooltip>
         <TooltipTrigger asChild>
           <a
-            className="flex items-center justify-center rounded-md text-primary hover:text-primary/80 visited:text-inherit"
+            className="flex items-center justify-center p-1 rounded-full text-primary bg-gray-200/70 hover:bg-gray-200/40 hover:text-primary/80 visited:text-inherit"
             href={link}
             target="_blank"
             rel="noreferrer"

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -1,4 +1,3 @@
-import { types } from "@mozilla/nimbus-shared";
 import {
   experimentColumns,
   FxMSMessageInfo,
@@ -107,8 +106,6 @@ async function getASRouterLocalColumnFromJSON(
 }
 
 let columnsShown = false;
-
-type NimbusExperiment = types.experiments.NimbusExperiment;
 
 /**
  * Appends any FxMS telemetry message data from the query in Look

--- a/lib/experimentUtils.ts
+++ b/lib/experimentUtils.ts
@@ -1,6 +1,3 @@
-import { types } from "@mozilla/nimbus-shared";
-type NimbusExperiment = types.experiments.NimbusExperiment;
-
 /**
  * These are the Nimbus feature IDs that correspond to messaging experiments.
  * Other Nimbus features contain specific variables whose keys are enumerated in

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -40,6 +40,10 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
       surface: "Menu Messages",
       tagColor: "bg-pink-300",
     },
+    menu_message: {
+      surface: "Menu Messages",
+      tagColor: "bg-pink-300",
+    },
     milestone_message: {
       surface: "Milestone Messages",
       tagColor: "bg-green-400",

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -40,10 +40,6 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
       surface: "Menu Messages",
       tagColor: "bg-pink-300",
     },
-    menu_message: {
-      surface: "Menu Messages",
-      tagColor: "bg-pink-300",
-    },
     milestone_message: {
       surface: "Milestone Messages",
       tagColor: "bg-green-400",

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -16,6 +16,11 @@ import { getExperimentLookerDashboardDate } from "./lookerUtils.ts";
 
 type NimbusExperiment = types.experiments.NimbusExperiment;
 
+type DocumentationLink = {
+  title: string;
+  link: string;
+};
+
 function isMessagingFeature(featureId: string): boolean {
   return MESSAGING_EXPERIMENTS_DEFAULT_FEATURES.includes(featureId);
 }
@@ -320,6 +325,9 @@ export class NimbusRecipe implements NimbusRecipeType {
       nimbusExperiment: this._rawRecipe,
       branches: branchInfos,
       hasMicrosurvey: hasMicrosurvey,
+      experimentBriefLink: this.getExperimentBriefLink(
+        this._rawRecipe.documentationLinks,
+      ),
     };
   }
 
@@ -381,5 +389,27 @@ export class NimbusRecipe implements NimbusRecipeType {
     return `https://experimenter.services.mozilla.com/nimbus/${encodeURIComponent(
       this._rawRecipe.slug,
     )}/summary#${branchSlug}`;
+  }
+
+  /**
+   * @param documentationLinks a list of documentation links provided for this Nimbus recipe
+   * @returns the first documentation link of the experiment brief Google Doc if it exists
+   */
+  getExperimentBriefLink(
+    documentationLinks: DocumentationLink[] | undefined,
+  ): string | undefined {
+    if (documentationLinks) {
+      const brief = documentationLinks.find(
+        (documentationLink: DocumentationLink) => {
+          return (
+            documentationLink.title === "DESIGN_DOC" &&
+            documentationLink.link.startsWith(
+              "https://docs.google.com/document",
+            )
+          );
+        },
+      );
+      return brief && brief.link;
+    }
   }
 }

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -14,7 +14,9 @@ import {
 } from "../lib/experimentUtils.ts";
 import { getExperimentLookerDashboardDate } from "./lookerUtils.ts";
 
-type NimbusExperiment = types.experiments.NimbusExperiment;
+// type NimbusExperiment = types.experiments.NimbusExperiment;
+const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
+type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
 
 type DocumentationLink = {
   title: string;

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -1,4 +1,3 @@
-import { types } from "@mozilla/nimbus-shared";
 import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "../app/columns.jsx";
 import {
   getDashboard,
@@ -14,14 +13,10 @@ import {
 } from "../lib/experimentUtils.ts";
 import { getExperimentLookerDashboardDate } from "./lookerUtils.ts";
 
-// type NimbusExperiment = types.experiments.NimbusExperiment;
 const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
 type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
-
-type DocumentationLink = {
-  title: string;
-  link: string;
-};
+type DocumentationLink =
+  typeof nimbusExperimentV7Schema.properties.documentationLinks;
 
 function isMessagingFeature(featureId: string): boolean {
   return MESSAGING_EXPERIMENTS_DEFAULT_FEATURES.includes(featureId);

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -13,6 +13,10 @@ import {
 } from "../lib/experimentUtils.ts";
 import { getExperimentLookerDashboardDate } from "./lookerUtils.ts";
 
+/**
+ * Type aliasing is used here to convert the NimbusExperiment JSON schema for
+ * the v7 api to be used for TypeScript objects.
+ */
 const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
 type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
 type DocumentationLink =

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -1,10 +1,8 @@
-import { types } from "@mozilla/nimbus-shared";
 import { NimbusRecipe } from "../lib/nimbusRecipe";
 import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "@/app/columns";
 import { getCTRPercentData } from "./looker";
 import { getExperimentLookerDashboardDate } from "./lookerUtils";
 
-// type NimbusExperiment = types.experiments.NimbusExperiment;
 const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
 type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
 

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -4,7 +4,9 @@ import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "@/app/columns";
 import { getCTRPercentData } from "./looker";
 import { getExperimentLookerDashboardDate } from "./lookerUtils";
 
-type NimbusExperiment = types.experiments.NimbusExperiment;
+// type NimbusExperiment = types.experiments.NimbusExperiment;
+const nimbusExperimentV7Schema = require("@mozilla/nimbus-schemas/schemas/NimbusExperimentV7.schema.json");
+type NimbusExperiment = typeof nimbusExperimentV7Schema.properties;
 
 type NimbusRecipeCollectionType = {
   recipes: Array<NimbusRecipe>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@auth0/nextjs-auth0": "^3.6.0",
         "@looker/sdk-node": "25.4.0",
         "@mozilla/nimbus-schemas": "^3001.0.0",
-        "@mozilla/nimbus-shared": "^2.5.2",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-navigation-menu": "^1.2.5",
         "@radix-ui/react-popover": "^1.1.6",
@@ -1510,17 +1509,6 @@
       "version": "3001.0.0",
       "resolved": "https://registry.npmjs.org/@mozilla/nimbus-schemas/-/nimbus-schemas-3001.0.0.tgz",
       "integrity": "sha512-yFUdwTo3yz77ybHcSpnvmGMjDXNVdU3B+H1L2ODWkGCaIyirK1OPYu/3jWrBZesgzTCsRQ+9WY5jqA86R+4HAA=="
-    },
-    "node_modules/@mozilla/nimbus-shared": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@mozilla/nimbus-shared/-/nimbus-shared-2.5.2.tgz",
-      "integrity": "sha512-upYplr3YNDcBrzbr5JxKQjAZuftFzIEdpbfm6RMq8ZXGZox6On2v5+5e99Z7Ecwzp/E3UwKcBhwumzfYaKMekw==",
-      "dependencies": {
-        "ajv": "^6.12.2"
-      },
-      "engines": {
-        "node": "^14.0.0"
-      }
     },
     "node_modules/@next/env": {
       "version": "14.2.25",
@@ -3138,6 +3126,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5095,7 +5084,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -5126,7 +5116,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -7238,7 +7229,8 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8896,6 +8888,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10376,6 +10369,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.6.0",
         "@looker/sdk-node": "25.4.0",
+        "@mozilla/nimbus-schemas": "^3001.0.0",
         "@mozilla/nimbus-shared": "^2.5.2",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-navigation-menu": "^1.2.5",
@@ -1504,6 +1505,11 @@
         "node": ">=12",
         "npm": ">=5.5.1"
       }
+    },
+    "node_modules/@mozilla/nimbus-schemas": {
+      "version": "3001.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/nimbus-schemas/-/nimbus-schemas-3001.0.0.tgz",
+      "integrity": "sha512-yFUdwTo3yz77ybHcSpnvmGMjDXNVdU3B+H1L2ODWkGCaIyirK1OPYu/3jWrBZesgzTCsRQ+9WY5jqA86R+4HAA=="
     },
     "node_modules/@mozilla/nimbus-shared": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.6.0",
     "@looker/sdk-node": "25.4.0",
+    "@mozilla/nimbus-schemas": "^3001.0.0",
     "@mozilla/nimbus-shared": "^2.5.2",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-navigation-menu": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@auth0/nextjs-auth0": "^3.6.0",
     "@looker/sdk-node": "25.4.0",
     "@mozilla/nimbus-schemas": "^3001.0.0",
-    "@mozilla/nimbus-shared": "^2.5.2",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-navigation-menu": "^1.2.5",
     "@radix-ui/react-popover": "^1.1.6",


### PR DESCRIPTION
[Bug 1891121](https://bugzilla.mozilla.org/show_bug.cgi?id=1891121)

Changes made:
- `RecipeInfo` now includes an `experimentBriefLink` property with the url to experiment link Google docs
- A tooltip button of the `FileText` icon from lucide-icons is now displayed next to the experiment/rollout name if an experiment brief link exists
- The package `@mozilla/nimbus-schemas` has been imported and replaces the `NimbusExperiment` type used from `@mozilla/nimbus-shared`