### PR TITLE
Fix the Firefox pill in the Timeline component

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -1,0 +1,36 @@
+import Dashboard from "@/app/page";
+import CompleteExperimentsDashboard from "@/app/complete/page";
+import { render } from "@testing-library/react";
+import { ExperimentFakes } from "../ExperimentFakes.mjs";
+import { BranchInfo } from "@/app/columns";
+
+const fakeFetchData: BranchInfo[] = [ExperimentFakes.recipe()];
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve(fakeFetchData),
+  }),
+) as jest.Mock;
+
+describe("Page", () => {
+  it("all timeline pill ids exist in the Dashboard component in /", async () => {
+    const dashboard = render(await Dashboard());
+
+    const firefox = dashboard.getByTestId("firefox");
+    const experiments = dashboard.getByTestId("live_experiments");
+    const rollouts = dashboard.getByTestId("live_rollouts");
+
+    expect(firefox).toBeDefined();
+    expect(experiments).toBeDefined();
+    expect(rollouts).toBeDefined();
+  });
+
+  it("all timeline pill ids exist in the Dashboard component in /complete", async () => {
+    const dashboard = render(await CompleteExperimentsDashboard());
+
+    const experiments = dashboard.getByTestId("complete_experiments");
+    const rollouts = dashboard.getByTestId("complete_rollouts");
+
+    expect(experiments).toBeDefined();
+    expect(rollouts).toBeDefined();
+  });
+});

--- a/app/complete/page.tsx
+++ b/app/complete/page.tsx
@@ -99,7 +99,11 @@ export default async function CompleteExperimentsDashboard() {
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
         Complete Desktop Message Rollouts
       </h5>
-      <h5 id="complete_rollouts" className="scroll-m-20 text-sm text-center">
+      <h5
+        id="complete_rollouts"
+        data-testid="complete_rollouts"
+        className="scroll-m-20 text-sm text-center"
+      >
         Total: {totalRolloutExperiments}
       </h5>
       <div className="sticky top-24 z-10 py-2 bg-background flex justify-center">
@@ -116,7 +120,11 @@ export default async function CompleteExperimentsDashboard() {
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
         Complete Desktop Message Experiments
       </h5>
-      <h5 id="complete_experiments" className="scroll-m-20 text-sm text-center">
+      <h5
+        id="complete_experiments"
+        data-testid="complete_experiments"
+        className="scroll-m-20 text-sm text-center"
+      >
         Total: {totalExperiments}
       </h5>
       <div className="sticky top-24 z-10 py-2 bg-background flex justify-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -239,7 +239,10 @@ export default async function Dashboard() {
         <MenuButton isComplete={false} />
       </div>
 
-      <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4 flex items-center justify-center gap-x-1">
+      <h5
+        id="firefox"
+        className="scroll-m-20 text-xl font-semibold text-center pt-6 flex items-center justify-center gap-x-1"
+      >
         Desktop Messages Released on Firefox
         <InfoPopover
           content="All messages listed in this table are in the release channel and are either currently live or have been live on Firefox at one time."

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -241,6 +241,7 @@ export default async function Dashboard() {
 
       <h5
         id="firefox"
+        data-testid="firefox"
         className="scroll-m-20 text-xl font-semibold text-center pt-6 flex items-center justify-center gap-x-1"
       >
         Desktop Messages Released on Firefox
@@ -265,7 +266,11 @@ export default async function Dashboard() {
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
         Current Desktop Message Rollouts
       </h5>
-      <h5 id="live_rollouts" className="scroll-m-20 text-sm text-center">
+      <h5
+        id="live_rollouts"
+        data-testid="live_rollouts"
+        className="scroll-m-20 text-sm text-center"
+      >
         Total: {totalRolloutExperiments}
       </h5>
       <div className="sticky top-24 z-10 bg-background py-2 flex justify-center">
@@ -282,7 +287,11 @@ export default async function Dashboard() {
       <h5 className="scroll-m-20 text-xl font-semibold text-center pt-4">
         Current Desktop Message Experiments
       </h5>
-      <h5 id="live_experiments" className="scroll-m-20 text-sm text-center">
+      <h5
+        id="live_experiments"
+        data-testid="live_experiments"
+        className="scroll-m-20 text-sm text-center"
+      >
         Total: {totalExperiments}
       </h5>
       <div className="sticky top-24 z-10 bg-background py-2 flex justify-center">


### PR DESCRIPTION
**Description**

The `firefox` id was removed from a previous patch which caused the Firefox pill in the Timeline component to be broken. 

**Changes made:**

- Added a `firefox` id to the live message table heading and adjusted padding