### PR TITLE
Fix for long message IDs that break the UI

### DIFF
--- a/__tests__/app/message-table.test.tsx
+++ b/__tests__/app/message-table.test.tsx
@@ -571,6 +571,31 @@ describe("MessageTable", () => {
         expect(defaultAboutWelcomeMsg).toBeInTheDocument();
       });
     });
+
+    it("truncates message ID if it's over 50 characters long", () => {
+      const messageId =
+        "12345678901234567890123456789012345678901234567890 is 50 characters long";
+      const fakeMsgInfo: FxMSMessageInfo = {
+        product: "Desktop",
+        id: messageId,
+        template: "test template",
+        surface: "test surface",
+        segment: "test segment",
+        metrics: "test metrics",
+        ctrDashboardLink: "test link",
+      };
+      render(
+        <MessageTable columns={fxmsMessageColumns} data={[fakeMsgInfo]} />,
+      );
+
+      const message = screen.queryByText(messageId);
+      const truncatedMessage = screen.queryByText(
+        "12345678901234567890123456789012345678901234567890...",
+      );
+
+      expect(message).not.toBeInTheDocument();
+      expect(truncatedMessage).toBeInTheDocument();
+    });
   });
 
   describe("CompletedExperimentColumns", () => {

--- a/__tests__/app/message-table.test.tsx
+++ b/__tests__/app/message-table.test.tsx
@@ -590,7 +590,7 @@ describe("MessageTable", () => {
 
       const message = screen.queryByText(messageId);
       const truncatedMessage = screen.queryByText(
-        "12345678901234567890123456789012345678901234567890...",
+        "12345678901234567890123456789012345678901234567890…",
       );
 
       expect(message).not.toBeInTheDocument();

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -197,7 +197,7 @@ export const fxmsMessageColumns: ColumnDef<FxMSMessageInfo>[] = [
             {/* Quick fix for long message IDs that can break the UI */}
             {props.row.original.id.length <= 50
               ? props.row.original.id
-              : props.row.original.id.substring(0, 50) + "..."}
+              : props.row.original.id.substring(0, 50) + "…"}
           </div>
           {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
         </>

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -194,7 +194,10 @@ export const fxmsMessageColumns: ColumnDef<FxMSMessageInfo>[] = [
       return (
         <>
           <div className="font-mono text-xs inline">
-            {props.row.original.id}
+            {/* Quick fix for long message IDs that can break the UI */}
+            {props.row.original.id.length <= 50
+              ? props.row.original.id
+              : props.row.original.id.substring(0, 50) + "..."}
           </div>
           {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
         </>


### PR DESCRIPTION
**Changes made:**
- Truncates (and adds an ellipses) message IDs in the live message table to be max 50 characters
- Added a simple test to check that truncating occurs for long message IDs
