### PR TITLE
Bug 1944394 - Update surface data to include menu messages

### DIFF
--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -36,6 +36,10 @@ export function getSurfaceDataForTemplate(template: string): SurfaceData {
       tagColor: "bg-lime-300",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
     },
+    menu: {
+      surface: "Menu Messages",
+      tagColor: "bg-pink-300",
+    },
     milestone_message: {
       surface: "Milestone Messages",
       tagColor: "bg-green-400",


### PR DESCRIPTION
[Bug 1944394](https://bugzilla.mozilla.org/show_bug.cgi?id=1944394)

Changes made:
- Added a "Menu Messages" surface to recognize the surface type for `DEVICE_MIGRATION_FXA_CTA_EXP1`