### PR TITLE
Update @auth0/nextjs-auth0 to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@mozilla/skylight",
       "version": "0.1.0",
       "dependencies": {
-        "@auth0/nextjs-auth0": "^3.5.0",
+        "@auth0/nextjs-auth0": "^3.6.0",
         "@looker/sdk-node": "25.2.0",
         "@mozilla/nimbus-shared": "^2.5.2",
         "@radix-ui/react-checkbox": "^1.1.4",
@@ -95,12 +95,13 @@
       }
     },
     "node_modules/@auth0/nextjs-auth0": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-3.5.0.tgz",
-      "integrity": "sha512-uFZEE2QQf1zU+jRK2fwqxRQt+WSqDPYF2tnr7d6BEa7b6L6tpPJ3evzoImbWSY1a7gFdvD7RD/Rvrsx7B5CKVg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-3.6.0.tgz",
+      "integrity": "sha512-d29jmwmmmhQKJBrdBHQNlBf4rZLH/qz1522cyf8HQTGQYXqHRLh+X1KOG0FyNkao2GN4Xnb856/o1XIlPt5ELQ==",
+      "license": "MIT",
       "dependencies": {
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.1",
         "debug": "^4.3.4",
         "joi": "^17.6.0",
         "jose": "^4.9.2",
@@ -3959,9 +3960,10 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "npm": "10.9.*"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^3.5.0",
+    "@auth0/nextjs-auth0": "^3.6.0",
     "@looker/sdk-node": "25.2.0",
     "@mozilla/nimbus-shared": "^2.5.2",
     "@radix-ui/react-checkbox": "^1.1.4",


### PR DESCRIPTION
This fixes a security issue caused by depending on a vulnerable version of the cookie package.