### PR TITLE
Bug 1957438 - Fix ctr for infobar Looker dashboards

### DIFF
--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -216,7 +216,7 @@ export function getPreviewLink(message: any): string {
  */
 export function getDashboardIdForTemplate(template: string) {
   if (template === "infobar") {
-    return "1809";
+    return "2267";
   } else {
     return "1818";
   }


### PR DESCRIPTION
Changes made:
- Updated the infobar Looker dashboard ID to link to [the updated dashboard](https://mozilla.cloud.looker.com/dashboards/2267?Messaging+System+Ping+Type=infobar&Submission+Date=30+days&Messaging+System+Message+Id=&Normalized+Channel=&Normalized+OS=&Client+Info+App+Display+Version=&Normalized+Country+Code=&Experiment=&Experiment+Branch=)
- The primary rate calculations in the new dashboard has been updated from
```
    pivot_index(${messaging_system.ping_count}, 1),
    0)
  / pivot_index(${messaging_system.ping_count}, 4)
```
to
```
    pivot_where(${messaging_system.metrics__string__messaging_system_event} = "CLICK_PRIMARY_BUTTON", ${messaging_system.ping_count}),
    0)
  / pivot_where(${messaging_system.metrics__string__messaging_system_event} = "IMPRESSION", ${messaging_system.ping_count})
```
