### PR TITLE
Add tooltip for experimenter links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Thursday, April 10th, 2025
+
+### Added
+- Added buttons to link to experiment brief pages for each experiment/rollout
+- Added tooltips over experiment brief buttons and experiment/rollout names
+- Added live message data from releases 131-135
+
+### Fixed
+- Fixed CTR calculations for infobar dashboards
+
 ## Wednesday, October 23rd, 2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## Thursday, April 10th, 2025
 
 ### Added
+
 - Added buttons to link to experiment brief pages for each experiment/rollout
 - Added tooltips over experiment brief buttons and experiment/rollout names
 - Added live message data from releases 131-135
 
 ### Fixed
+
 - Fixed CTR calculations for infobar dashboards
 
 ## Wednesday, October 23rd, 2024

--- a/__tests__/app/message-table.test.tsx
+++ b/__tests__/app/message-table.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MessageTable } from "@/app/message-table";
 import {
   completedExperimentColumns,

--- a/__tests__/app/message-table.test.tsx
+++ b/__tests__/app/message-table.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MessageTable } from "@/app/message-table";
 import {
   completedExperimentColumns,
@@ -306,6 +312,26 @@ describe("MessageTable", () => {
       const microsurveyBadge = screen.getByText("Microsurvey");
 
       expect(microsurveyBadge).toBeInTheDocument();
+    });
+
+    it("displays a tooltip when hovering on an experiment name", async () => {
+      const user = userEvent.setup();
+      const rawRecipe = ExperimentFakes.recipe("test-recipe", {
+        userFacingName: "Test Experiment Name",
+      });
+      const nimbusRecipe = new NimbusRecipe(rawRecipe);
+      const messageTableData: RecipeInfo[] = [nimbusRecipe.getRecipeInfo()];
+      render(
+        <MessageTable columns={experimentColumns} data={messageTableData} />,
+      );
+
+      await act(async () => {
+        await user.hover(screen.getByText("Test Experiment Name"));
+      });
+      const tooltip = await screen.findByRole("tooltip");
+
+      expect(tooltip).toBeInTheDocument();
+      expect(tooltip).toHaveTextContent("Go to Experimenter page");
     });
   });
 

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   FileText,
+  SquareArrowOutUpRight,
 } from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import { InfoPopover } from "@/components/ui/infopopover";
@@ -46,24 +47,12 @@ function OffsiteLink(href: string, linkText: any) {
   return (
     <a
       href={href}
-      className="text-xs/[180%] whitespace-nowrap"
+      className="text-xs/[180%] whitespace-nowrap flex flex-row items-center gap-x-1"
       target="_blank"
       rel="noreferrer"
     >
       {linkText}
-      <svg
-        fill="none"
-        viewBox="0 0 8 8"
-        className="inline h-[1.1rem] w-[1.1rem] px-1"
-        aria-hidden="true"
-      >
-        <path
-          clipRule="evenodd"
-          d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"
-          fill="#5e5e72"
-          fillRule="evenodd"
-        ></path>
-      </svg>
+      <SquareArrowOutUpRight size={10} />
     </a>
   );
 }
@@ -202,6 +191,35 @@ function experimentBriefTooltip(link: string) {
         </TooltipTrigger>
         <TooltipContent>
           <p>See experiment brief</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function experimenterLinkTooltip(
+  link: string,
+  hasMicrosurvey: boolean,
+  id: string,
+  userFacingName?: string,
+) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <a
+            href={link}
+            className="font-semibold text-sm flex flex-row items-center gap-x-1 text-primary visited:text-inherit hover:text-blue-800 no-underline whitespace-nowrap"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {hasMicrosurvey && <> {microsurveyBadge} </>}
+            {userFacingName || id}
+            <SquareArrowOutUpRight size={13} className="overflow-visible" />
+          </a>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Go to Experimenter page</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -408,30 +426,12 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
             {props.row.original.experimentBriefLink &&
               experimentBriefTooltip(props.row.original.experimentBriefLink)}
             <div className="flex flex-col gap-y-1 w-[24rem] overflow-visible">
-              <a
-                href={props.row.original.experimenterLink}
-                className="font-semibold text-sm flex flex-row items-center gap-x-1 text-primary visited:text-inherit hover:text-blue-800 no-underline whitespace-nowrap"
-                target="_blank"
-                rel="noreferrer"
-              >
-                {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
-                {props.row.original.userFacingName || props.row.original.id}
-                {/* XXX switch to a Lucide icon for external link */}
-                <svg
-                  fill="currentColor"
-                  fillOpacity="0.6"
-                  viewBox="0 0 8 8"
-                  className="inline h-3 w-3"
-                  aria-hidden="true"
-                  style={{
-                    marginInline: "0.1rem 0",
-                    paddingBlock: "0 0.1rem",
-                    overflow: "visible",
-                  }}
-                >
-                  <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
-                </svg>
-              </a>
+              {experimenterLinkTooltip(
+                props.row.original.experimenterLink,
+                props.row.original.hasMicrosurvey,
+                props.row.original.id,
+                props.row.original.userFacingName,
+              )}
               <div className="font-mono text-3xs">{props.row.original.id}</div>
             </div>
           </div>
@@ -449,17 +449,7 @@ export const experimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
             rel="noreferrer"
           >
             {props.row.original.description || props.row.original.id}
-            {/* XXX switch to a Lucide icon for external link */}
-            <svg
-              fill="currentColor"
-              fillOpacity="0.6"
-              viewBox="0 0 8 8"
-              className="inline h-[1.0rem] w-[1.0rem] px-1"
-              aria-hidden="true"
-              style={{ paddingBlock: "0 0.1rem", overflow: "visible" }}
-            >
-              <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
-            </svg>
+            <SquareArrowOutUpRight size={10} className="inline ml-1" />
           </a>
           <p className="font-mono text-3xs">{props.row.original.slug}</p>
         </div>
@@ -611,36 +601,18 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
     cell: (props: any) => {
       if (props.row.original.userFacingName) {
         return (
-          <div>
-            <div className="flex flex-row gap-x-2 items-center">
-              {props.row.original.experimentBriefLink &&
-                experimentBriefTooltip(props.row.original.experimentBriefLink)}
-              {props.row.original.hasMicrosurvey && <> {microsurveyBadge} </>}
-              <a
-                href={props.row.original.experimenterLink}
-                className="font-semibold text-sm text-primary visited:text-inherit hover:text-blue-800 no-underline"
-                target="_blank"
-                rel="noreferrer"
-              >
-                {props.row.original.userFacingName || props.row.original.id}
-                {/* XXX switch to a Lucide icon for external link */}
-                <svg
-                  fill="currentColor"
-                  fillOpacity="0.6"
-                  viewBox="0 0 8 8"
-                  className="inline h-[1.2rem] w-[1.2rem] px-1"
-                  aria-hidden="true"
-                  style={{
-                    marginInline: "0.1rem 0",
-                    paddingBlock: "0 0.1rem",
-                    overflow: "visible",
-                  }}
-                >
-                  <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
-                </svg>
-              </a>
+          <div className="flex flex-row gap-x-2 items-start">
+            {props.row.original.experimentBriefLink &&
+              experimentBriefTooltip(props.row.original.experimentBriefLink)}
+            <div className="flex flex-col gap-y-1 w-[24rem] overflow-visible">
+              {experimenterLinkTooltip(
+                props.row.original.experimenterLink,
+                props.row.original.hasMicrosurvey,
+                props.row.original.id,
+                props.row.original.userFacingName,
+              )}
+              <div className="font-mono text-3xs">{props.row.original.id}</div>
             </div>
-            <div className="font-mono text-3xs">{props.row.original.id}</div>
           </div>
         );
       }
@@ -656,17 +628,7 @@ export const completedExperimentColumns: ColumnDef<RecipeOrBranchInfo>[] = [
             rel="noreferrer"
           >
             {props.row.original.description || props.row.original.id}
-            {/* XXX switch to a Lucide icon for external link */}
-            <svg
-              fill="currentColor"
-              fillOpacity="0.6"
-              viewBox="0 0 8 8"
-              className="inline h-[1.0rem] w-[1.0rem] px-1"
-              aria-hidden="true"
-              style={{ paddingBlock: "0 0.1rem", overflow: "visible" }}
-            >
-              <path d="m1.71278 0h.57093c.31531 0 .57092.255837.57092.571429 0 .315591-.25561.571431-.57092.571431h-.57093c-.31531 0-.57093.25583-.57093.57143v4.57142c0 .3156.25562.57143.57093.57143h4.56741c.31531 0 .57093-.25583.57093-.57143v-.57142c0-.3156.25561-.57143.57092-.57143.31532 0 .57093.25583.57093.57143v.57142c0 .94678-.76684 1.71429-1.71278 1.71429h-4.56741c-.945943 0-1.71278-.76751-1.71278-1.71429v-4.57142c0-.946778.766837-1.71429 1.71278-1.71429zm5.71629 0c.23083.0002686.43879.13963.52697.353143.02881.069172.04375.143342.04396.218286v2.857141c0 .31559-.25561.57143-.57093.57143-.31531 0-.57092-.25584-.57092-.57143v-1.47771l-1.88006 1.88171c-.14335.14855-.35562.20812-.55523.15583-.19962-.0523-.35551-.20832-.40775-.40811-.05225-.19979.00727-.41225.15569-.55572l1.88006-1.88171h-1.47642c-.31531 0-.57093-.25584-.57093-.571431 0-.315592.25562-.571429.57093-.571429z"></path>
-            </svg>
+            <SquareArrowOutUpRight size={10} className="inline ml-1" />
           </a>
           <p className="font-mono text-3xs">{props.row.original.slug}</p>
         </div>


### PR DESCRIPTION
Changes made:
- This PR adds a tooltip to the experimenter links to further differentiate them from the experimenter brief buttons, as discussed in a previous Skylight meeting
- lucide-react icon has also replaced the external link svgs