### PR TITLE
Update Looker dashboard submission timestamp logic

### DIFF
--- a/__tests__/lib/lookerUtils.test.ts
+++ b/__tests__/lib/lookerUtils.test.ts
@@ -63,7 +63,7 @@ describe("getLookerSubmissionTimestampDateFilter", () => {
 
     const result = getLookerSubmissionTimestampDateFilter(startDate, endDate);
 
-    expect(result).toEqual("2024-05-08 to 3024-06-10");
+    expect(result).toEqual("2024-05-08 to today");
   });
 
   it("returns a date filter from the startDate to endDate when startDate and endDate are defined and the message is completed", () => {

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -142,9 +142,9 @@ describe("getDashboard", () => {
     const template = "feature_callout";
     const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
-    const endDate = "2025-06-28";
+    const endDate = "3025-06-28";
     const dashboardId = getDashboardIdForTemplate(template);
-    const submissionDate = "2024-03-08 to 2025-06-28";
+    const submissionDate = "2024-03-08 to today";
 
     const result = getDashboard(
       template,

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -47,12 +47,12 @@ function OffsiteLink(href: string, linkText: any) {
   return (
     <a
       href={href}
-      className="text-xs/[180%] whitespace-nowrap flex flex-row items-center gap-x-1"
+      className="text-xs/[180%] whitespace-nowrap"
       target="_blank"
       rel="noreferrer"
     >
       {linkText}
-      <SquareArrowOutUpRight size={10} />
+      <SquareArrowOutUpRight size={10} className="inline ml-1" />
     </a>
   );
 }

--- a/lib/lookerUtils.ts
+++ b/lib/lookerUtils.ts
@@ -41,19 +41,13 @@ export function getLookerSubmissionTimestampDateFilter(
 ): string {
   if (isCompleted && startDate && endDate) {
     // This case covers completed experiments with defined startDate and
-    // endDate from the Experimenter API.
-    return `${startDate} to ${endDate}`;
-  } else if (
-    !isCompleted &&
-    startDate &&
-    endDate &&
-    new Date() < new Date(endDate)
-  ) {
-    // This case covers experiments that haven't reached their proposed end date.
+    // endDate from the Experimenter API, with the endDate being today or earlier.
     return `${startDate} to ${endDate}`;
   } else if (startDate) {
-    // This case covers experiments that are still ongoing past their proposed
-    // end date.
+    // This case covers experiments that haven't reached their proposed end date.
+    // This case also covers experiments that are still ongoing past their proposed
+    // to prevent issues with the Looker dashboards showing no data for to dates in
+    // the future.
     return `${startDate} to today`;
   } else {
     // This case covers any messages with undefined startDate and endDate.


### PR DESCRIPTION
Changes made:
- Updates `getLookerSubmissionTimestampDateFilter` so that any endDate that is in the future gets set to today's date to avoid issues with the dashboard showing no data for future dates
- Also included a small fix to the external link icon for CTRs to be properly inline