### PR TITLE
Update Android Looker dashboard ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Updated
 
-- Updated the Looker dashboards for Android messaging experiments with a new tile to show total users profile impressed and the primary rate CTR
+- Updated the Looker dashboards for Android messaging experiments with a new tile to show total users profile impressed and the primary rate CTR. The new tile uses `pivot_where` in the CTR calculations to ensure proper columns are being used in the calculations.
 
 ## Wednesday, April 16th, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Thursday, April 17th, 2025
+
+### Updated
+
+- Updated the Looker dashboards for Android messaging experiments with a new tile to show total users profile impressed and the primary rate CTR
+
 ## Wednesday, April 16th, 2025
 
 ### Added

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -230,7 +230,7 @@ describe("getDashboard", () => {
     const branchSlug = "treatment:a";
     const startDate = "2025-03-08";
     const endDate = "2025-05-08";
-    const dashboardId = "2191";
+    const dashboardId = "2303";
     const submissionDate = "2025-03-08 to today";
 
     const result = getAndroidDashboard(

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -137,7 +137,7 @@ export function getAndroidDashboard(
 
   // XXX consider using a similar function like getDashboardIdForTemplate for
   // android dashboards to get dashboardId
-  const dashboardId = 2191; // messages/push notification
+  const dashboardId = 2303; // messages/push notification
   let baseUrl = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}`;
   let paramObj;
 


### PR DESCRIPTION
Changes made:
- Added a new tile to the android Looker dashboard https://mozilla.cloud.looker.com/dashboards/2303?Normalized%20Channel=release&Submission%20Date=30%20day&Experiment%20Slug=rootca-info-card-hcr1-fenix&Value%20Branch=&Sample%20ID=%3C%3D10&Value=info%5E_card%5E_rootCA%5E_HCR1%25
- Updated the looker dashboard ID for android so dashboard links point to the updated dashboard