### PR TITLE
Inline CTR and impressions data for Android messages

### DIFF
--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -11,27 +11,36 @@ jest.mock("../../lib/sdk");
 describe("Looker", () => {
   it("should return the first dashboard element", async () => {
     const template = "test_template";
-    const platform = "firefox-desktop";
-    const element = await looker.getDashboardElement0(platform, template);
+    const element = await looker.getDashboardElement0(template);
 
     expect(element).toEqual(fakeDashboardElements[0]);
   });
 
   it("should return the query results", async () => {
-    const platform = "firefox-desktop";
     const template = "test_template";
-    const queryResult = await looker.runQueryForSurface(
-      platform,
-      template,
-      fakeFilters,
-    );
+    const queryResult = await looker.runQueryForSurface(template, fakeFilters);
 
     expect(queryResult).toEqual(fakeQueryResult);
   });
 
-  it("should return the CTR percent of the primary rate", async () => {
+  it("should return the CTR percent of the primary rate of a desktop message", async () => {
     const id = "test_query_0";
     const platform = "firefox-desktop";
+    const template = "test_template";
+
+    const ctrPercentData = await looker.getCTRPercentData(
+      id,
+      platform,
+      template,
+    );
+
+    expect(ctrPercentData?.ctrPercent).toEqual(12.35);
+    expect(ctrPercentData?.impressions).toEqual(12899);
+  });
+
+  it("should return the CTR percent of the primary rate of an android message", async () => {
+    const id = "test_query_0";
+    const platform = "fenix";
     const template = "test_template";
 
     const ctrPercentData = await looker.getCTRPercentData(

--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -11,7 +11,8 @@ jest.mock("../../lib/sdk");
 describe("Looker", () => {
   it("should return the first dashboard element", async () => {
     const template = "test_template";
-    const element = await looker.getDashboardElement0(template);
+    const platform = "firefox-desktop";
+    const element = await looker.getDashboardElement0(platform, template);
 
     expect(element).toEqual(fakeDashboardElements[0]);
   });

--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -17,17 +17,27 @@ describe("Looker", () => {
   });
 
   it("should return the query results", async () => {
+    const platform = "firefox-desktop";
     const template = "test_template";
-    const queryResult = await looker.runQueryForTemplate(template, fakeFilters);
+    const queryResult = await looker.runQueryForTemplate(
+      platform,
+      template,
+      fakeFilters,
+    );
 
     expect(queryResult).toEqual(fakeQueryResult);
   });
 
   it("should return the CTR percent of the primary rate", async () => {
     const id = "test_query_0";
+    const platform = "firefox-desktop";
     const template = "test_template";
 
-    const ctrPercentData = await looker.getCTRPercentData(id, template);
+    const ctrPercentData = await looker.getCTRPercentData(
+      id,
+      platform,
+      template,
+    );
 
     expect(ctrPercentData?.ctrPercent).toEqual(12.35);
     expect(ctrPercentData?.impressions).toEqual(12899);

--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -11,7 +11,7 @@ jest.mock("../../lib/sdk");
 describe("Looker", () => {
   it("should return the first dashboard element", async () => {
     const template = "test_template";
-    const element = await looker.getAWDashboardElement0(template);
+    const element = await looker.getDashboardElement0(template);
 
     expect(element).toEqual(fakeDashboardElements[0]);
   });

--- a/__tests__/lib/looker.test.ts
+++ b/__tests__/lib/looker.test.ts
@@ -20,7 +20,7 @@ describe("Looker", () => {
   it("should return the query results", async () => {
     const platform = "firefox-desktop";
     const template = "test_template";
-    const queryResult = await looker.runQueryForTemplate(
+    const queryResult = await looker.runQueryForSurface(
       platform,
       template,
       fakeFilters,

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -1,10 +1,10 @@
 import {
-  getDashboard,
   _isAboutWelcomeTemplate,
   toBinary,
   getDashboardIdForSurface,
   messageHasMicrosurvey,
-  getAndroidDashboard,
+  getAndroidDashboardLink,
+  getDesktopDashboardLink,
 } from "@/lib/messageUtils";
 
 describe("isAboutWelcomeTemplate", () => {
@@ -75,7 +75,7 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "30 day ago for 30 day";
 
-    const result = getDashboard(
+    const result = getDesktopDashboardLink(
       template,
       msgId,
       channel,
@@ -100,7 +100,7 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "30 day ago for 30 day";
 
-    const result = getDashboard(template, msgId) as string;
+    const result = getDesktopDashboardLink(template, msgId) as string;
     const url = new URL(result);
     const params = url.searchParams;
 
@@ -121,7 +121,7 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "30 day ago for 30 day";
 
-    const result = getDashboard(
+    const result = getDesktopDashboardLink(
       template,
       msgId,
       undefined,
@@ -148,7 +148,7 @@ describe("getDashboard", () => {
     // The end date should be today to avoid showing null data for dates in the future
     const submissionDate = "2024-03-08 to today";
 
-    const result = getDashboard(
+    const result = getDesktopDashboardLink(
       template,
       msgId,
       undefined,
@@ -176,7 +176,7 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "2024-03-08 to today";
 
-    const result = getDashboard(
+    const result = getDesktopDashboardLink(
       template,
       msgId,
       undefined,
@@ -203,7 +203,7 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "2024-03-08 to today";
 
-    const result = getDashboard(
+    const result = getDesktopDashboardLink(
       template,
       msgId,
       undefined,
@@ -233,7 +233,7 @@ describe("getDashboard", () => {
     const dashboardId = getDashboardIdForSurface(surface);
     const submissionDate = "2025-03-08 to today";
 
-    const result = getAndroidDashboard(
+    const result = getAndroidDashboardLink(
       surface,
       msgIdPrefix,
       undefined,

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -230,7 +230,7 @@ describe("getDashboard", () => {
     const branchSlug = "treatment:a";
     const startDate = "2025-03-08";
     const endDate = "2025-05-08";
-    const dashboardId = "2191";
+    const dashboardId = "2303";
     const submissionDate = "2025-03-08 to today";
 
     const result = getAndroidDashboard(

--- a/__tests__/lib/messageUtils.test.ts
+++ b/__tests__/lib/messageUtils.test.ts
@@ -2,7 +2,7 @@ import {
   getDashboard,
   _isAboutWelcomeTemplate,
   toBinary,
-  getDashboardIdForTemplate,
+  getDashboardIdForSurface,
   messageHasMicrosurvey,
   getAndroidDashboard,
 } from "@/lib/messageUtils";
@@ -72,7 +72,7 @@ describe("getDashboard", () => {
     const channel = "release";
     const experiment = "experiment:test";
     const branchSlug = "treatment:a";
-    const dashboardId = getDashboardIdForTemplate(template);
+    const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "30 day ago for 30 day";
 
     const result = getDashboard(
@@ -97,7 +97,7 @@ describe("getDashboard", () => {
   it("returns a correct featureCallout dashboard link", () => {
     const template = "feature_callout";
     const msgId = "a:bc"; // weird chars to test URI encoding
-    const dashboardId = getDashboardIdForTemplate(template);
+    const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "30 day ago for 30 day";
 
     const result = getDashboard(template, msgId) as string;
@@ -118,7 +118,7 @@ describe("getDashboard", () => {
     const msgId = "a:bc"; // weird chars to test URI encoding
     const experiment = "experiment:test";
     const branchSlug = "treatment:a";
-    const dashboardId = getDashboardIdForTemplate(template);
+    const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "30 day ago for 30 day";
 
     const result = getDashboard(
@@ -144,7 +144,7 @@ describe("getDashboard", () => {
     const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
     const endDate = "3025-06-28";
-    const dashboardId = getDashboardIdForTemplate(template);
+    const dashboardId = getDashboardIdForSurface(template);
     // The end date should be today to avoid showing null data for dates in the future
     const submissionDate = "2024-03-08 to today";
 
@@ -173,7 +173,7 @@ describe("getDashboard", () => {
     const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
     const endDate = "2024-05-28";
-    const dashboardId = getDashboardIdForTemplate(template);
+    const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "2024-03-08 to today";
 
     const result = getDashboard(
@@ -200,7 +200,7 @@ describe("getDashboard", () => {
     const template = "feature_callout";
     const msgId = "a:bc"; // weird chars to test URI encoding
     const startDate = "2024-03-08";
-    const dashboardId = getDashboardIdForTemplate(template);
+    const dashboardId = getDashboardIdForSurface(template);
     const submissionDate = "2024-03-08 to today";
 
     const result = getDashboard(
@@ -224,17 +224,17 @@ describe("getDashboard", () => {
   });
 
   it("returns a correct dashboard link for Android messaging experiments", () => {
-    const template = "survey";
+    const surface = "survey";
     const msgIdPrefix = "a:bc-en-us"; // weird chars to test URI encoding
     const experiment = "experiment:test";
     const branchSlug = "treatment:a";
     const startDate = "2025-03-08";
     const endDate = "2025-05-08";
-    const dashboardId = "2303";
+    const dashboardId = getDashboardIdForSurface(surface);
     const submissionDate = "2025-03-08 to today";
 
     const result = getAndroidDashboard(
-      template,
+      surface,
       msgIdPrefix,
       undefined,
       experiment,

--- a/__tests__/lib/nimbusRecipe.test.ts
+++ b/__tests__/lib/nimbusRecipe.test.ts
@@ -1,7 +1,10 @@
 import { NimbusRecipe } from "@/lib/nimbusRecipe";
 import { ExperimentFakes } from "@/__tests__/ExperimentFakes.mjs";
 import { BranchInfo } from "@/app/columns.jsx";
-import { getAndroidDashboard, getDashboard } from "@/lib/messageUtils";
+import {
+  getAndroidDashboardLink,
+  getDesktopDashboardLink,
+} from "@/lib/messageUtils";
 import { getExperimentLookerDashboardDate } from "@/lib/lookerUtils";
 import { formatDate } from "@/lib/experimentUtils";
 
@@ -194,7 +197,7 @@ describe("NimbusRecipe", () => {
           1,
         );
 
-        const dashboardLink = getDashboard(
+        const dashboardLink = getDesktopDashboardLink(
           branchInfo.template as string,
           branchInfo.id,
           undefined,
@@ -249,7 +252,7 @@ describe("NimbusRecipe", () => {
           1,
         );
 
-        const dashboardLink = getDashboard(
+        const dashboardLink = getDesktopDashboardLink(
           branchInfo.template as string,
           branchInfo.id,
           undefined,
@@ -293,7 +296,7 @@ describe("NimbusRecipe", () => {
           branchInfo.nimbusExperiment.endDate as string,
           1,
         );
-        const dashboardLink = getAndroidDashboard(
+        const dashboardLink = getAndroidDashboardLink(
           branchInfo.template as string,
           branchInfoId,
           undefined,

--- a/app/columns.tsx
+++ b/app/columns.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { PrettyDateRange } from "./dates";
 import { InfoPopover } from "@/components/ui/infopopover";
-import { getSurfaceDataForTemplate } from "@/lib/messageUtils";
+import { getSurfaceData } from "@/lib/messageUtils";
 import { HIDE_DASHBOARD_EXPERIMENTS } from "@/lib/experimentUtils";
 import {
   Tooltip,
@@ -21,7 +21,7 @@ import {
 } from "@/components/ui/tooltip";
 
 function SurfaceTag(template: string, surface: string) {
-  const { tagColor, docs } = getSurfaceDataForTemplate(template);
+  const { tagColor, docs } = getSurfaceData(template);
   const anchorTagClassName =
     "text-primary visited:text-primary hover:text-secondary hover:bg-opacity-80 cursor-pointer hover:no-underline ";
   const surfaceTagClassName =

--- a/app/fetchData.ts
+++ b/app/fetchData.ts
@@ -3,7 +3,7 @@ import {
   compareSurfacesFn,
   getDashboard,
   getPreviewLink,
-  getSurfaceDataForTemplate,
+  getSurfaceData,
   getTemplateFromMessage,
   maybeCreateWelcomePreview,
   messageHasMicrosurvey,
@@ -161,8 +161,7 @@ export async function getASRouterLocalColumnFromJSON(
     product: "Desktop",
     id: messageDef.id,
     template: messageDef.template,
-    surface: getSurfaceDataForTemplate(getTemplateFromMessage(messageDef))
-      .surface,
+    surface: getSurfaceData(getTemplateFromMessage(messageDef)).surface,
     segment: "some segment",
     metrics: "some metrics",
     ctrPercent: undefined, // may be populated from Looker data

--- a/app/fetchData.ts
+++ b/app/fetchData.ts
@@ -1,7 +1,7 @@
 // XXX ultimately, this wants to live in lib/fetchData.ts, but we need to get rid of our dependency on columns.tsx first.
 import {
   compareSurfacesFn,
-  getDashboard,
+  getDesktopDashboardLink,
   getPreviewLink,
   getSurfaceData,
   getTemplateFromMessage,
@@ -188,7 +188,7 @@ export async function getASRouterLocalColumnFromJSON(
     }
   }
 
-  fxmsMsgInfo.ctrDashboardLink = getDashboard(
+  fxmsMsgInfo.ctrDashboardLink = getDesktopDashboardLink(
     fxmsMsgInfo.template,
     fxmsMsgInfo.id,
     channel,

--- a/app/fetchData.ts
+++ b/app/fetchData.ts
@@ -174,10 +174,12 @@ export async function getASRouterLocalColumnFromJSON(
   };
 
   const channel = "release";
+  const platform = "firefox-desktop";
 
   if (isLookerEnabled) {
     const ctrPercentData = await getCTRPercentData(
       fxmsMsgInfo.id,
+      platform,
       fxmsMsgInfo.template,
       channel,
     );

--- a/lib/__mocks__/sdk.ts
+++ b/lib/__mocks__/sdk.ts
@@ -32,6 +32,17 @@ export const fakeQueryResult = [
     },
   },
 ];
+export const fakeAndroidQueryResult = [
+  {
+    primary_rate: 0.123456789,
+    "event.client_count": {
+      "events.event_name": {
+        message_shown: 12899,
+        message_clicked: 1592,
+      },
+    },
+  },
+];
 
 export function getLookerSDK(): any {
   return "mocked SDK";

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -1,6 +1,6 @@
 import { IDashboardElement, IWriteQuery } from "@looker/sdk";
 import { SDK } from "./sdk";
-import { getDashboardIdForTemplate } from "./messageUtils";
+import { getDashboardIdForSurface } from "./messageUtils";
 import { getLookerSubmissionTimestampDateFilter } from "./lookerUtils";
 import { Platform } from "./types";
 
@@ -19,7 +19,7 @@ export async function getDashboardElement0(
       dashboardId = "2303";
       break;
     default:
-      dashboardId = getDashboardIdForTemplate(template);
+      dashboardId = getDashboardIdForSurface(template);
   }
 
   // XXX maybe switch this out for the more performant dashboard_element (see

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -46,7 +46,6 @@ export async function runLookQuery(lookId: string): Promise<string> {
 }
 
 /**
- * @param platform the message platform
  * @param template the message template
  * @param filters an object containing any filters used in the Looker query (eg. channel, templates, experiment, branch)
  * @param startDate the experiment start date
@@ -160,8 +159,8 @@ export async function getAndroidCTRPercentData(
         "events.normalized_channel": channel,
         "events_unnested_table__ping_info__experiments.key": experiment,
         "events_unnested_table__ping_info__experiments.value__branch": branch,
-        "events.sample_id": "to 10", // Sample ID <= 10
-        "events.event_category": "messaging", // XXX
+        "events.sample_id": "to 10", // XXX This is equal to Sample ID <= 10
+        "events.event_category": "messaging", // XXX this should be updated once we support more Android Looker dashboards
         "events_unnested_table__event_extra.value": id.slice(0, -5) + "%",
       },
       startDate,

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -10,17 +10,9 @@ export type CTRData = {
 };
 
 export async function getDashboardElement0(
-  platform: Platform,
   template: string,
 ): Promise<IDashboardElement> {
-  let dashboardId;
-  switch (platform) {
-    case "fenix":
-      dashboardId = "2303";
-      break;
-    default:
-      dashboardId = getDashboardIdForSurface(template);
-  }
+  const dashboardId = getDashboardIdForSurface(template);
 
   // XXX maybe switch this out for the more performant dashboard_element (see
   // https://mozilla.cloud.looker.com/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Dashboard/dashboard_element
@@ -62,13 +54,12 @@ export async function runLookQuery(lookId: string): Promise<string> {
  * @returns the result of the query that is created by the given filters and filter_expression, and the appropriate template and submission timestamp
  */
 export async function runQueryForSurface(
-  platform: Platform,
   template: string,
   filters: any,
   startDate?: string | null,
   endDate?: string | null,
 ): Promise<any> {
-  const element0 = await getDashboardElement0(platform, template);
+  const element0 = await getDashboardElement0(template);
 
   const origQuery = element0.query as IWriteQuery;
 
@@ -128,7 +119,6 @@ export async function getCTRPercentData(
     case "fenix":
       return getAndroidCTRPercentData(
         id,
-        platform,
         template,
         channel,
         experiment,
@@ -139,7 +129,6 @@ export async function getCTRPercentData(
     default:
       return getDesktopCTRPercentData(
         id,
-        platform,
         template,
         channel,
         experiment,
@@ -152,7 +141,6 @@ export async function getCTRPercentData(
 
 export async function getAndroidCTRPercentData(
   id: string,
-  platform: Platform,
   template: string,
   channel?: string,
   experiment?: string,
@@ -167,7 +155,6 @@ export async function getAndroidCTRPercentData(
   let queryResult;
   if (template === "survey") {
     queryResult = await runQueryForSurface(
-      platform,
       template,
       {
         "events.normalized_channel": channel,
@@ -203,7 +190,6 @@ export async function getAndroidCTRPercentData(
 
 export async function getDesktopCTRPercentData(
   id: string,
-  platform: Platform,
   template: string,
   channel?: string,
   experiment?: string,
@@ -218,7 +204,6 @@ export async function getDesktopCTRPercentData(
   let queryResult;
   if (template === "infobar") {
     queryResult = await runQueryForSurface(
-      platform,
       template,
       {
         "messaging_system.metrics__text2__messaging_system_message_id": id,
@@ -233,7 +218,6 @@ export async function getDesktopCTRPercentData(
     );
   } else {
     queryResult = await runQueryForSurface(
-      platform,
       template,
       {
         "event_counts.message_id": "%" + id + "%",

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -10,9 +10,15 @@ export type CTRData = {
 };
 
 export async function getDashboardElement0(
+  platform: Platform,
   template: string,
 ): Promise<IDashboardElement> {
-  const dashboardId = getDashboardIdForTemplate(template);
+  let dashboardId;
+  if (platform === "fenix") {
+    dashboardId = "2303";
+  } else {
+    dashboardId = getDashboardIdForTemplate(template);
+  }
 
   // XXX maybe switch this out for the more performant dashboard_element (see
   // https://mozilla.cloud.looker.com/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Dashboard/dashboard_element
@@ -60,7 +66,7 @@ export async function runQueryForTemplate(
   startDate?: string | null,
   endDate?: string | null,
 ): Promise<any> {
-  const element0 = await getDashboardElement0(template);
+  const element0 = await getDashboardElement0(platform, template);
 
   const origQuery = element0.query as IWriteQuery;
 
@@ -176,6 +182,7 @@ export async function getAndroidCTRPercentData(
   // this code are worth applying some manual performance checking.
   let queryResult;
   if (template === "survey") {
+    console.log("[getAndroidCTRPercentData] platform: " + platform);
     queryResult = await runQueryForTemplate(
       platform,
       template,
@@ -183,7 +190,9 @@ export async function getAndroidCTRPercentData(
         "events.normalized_channel": channel,
         "events_unnested_table__ping_info__experiments.key": experiment,
         "events_unnested_table__ping_info__experiments.value__branch": branch,
-        "events_unnested_table__event_extra.value": id,
+        "events.sample_id": "to 10", // Sample ID <= 10
+        "events.event_category": "messaging", // XXX
+        "events_unnested_table__event_extra.value": id + "%",
       },
       startDate,
       endDate,
@@ -224,6 +233,7 @@ export async function getDesktopCTRPercentData(
   // those filters to sync up the data in both places. Non-trivial changes to
   // this code are worth applying some manual performance checking.
   let queryResult;
+  console.log("[getDesktopCTRPercentData] platform: " + platform);
   if (template === "infobar") {
     queryResult = await runQueryForTemplate(
       platform,

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -8,7 +8,7 @@ export type CTRData = {
   impressions: number;
 };
 
-export async function getAWDashboardElement0(
+export async function getDashboardElement0(
   template: string,
 ): Promise<IDashboardElement> {
   const dashboardId = getDashboardIdForTemplate(template);
@@ -57,7 +57,7 @@ export async function runQueryForTemplate(
   startDate?: string | null,
   endDate?: string | null,
 ): Promise<any> {
-  const element0 = await getAWDashboardElement0(template);
+  const element0 = await getDashboardElement0(template);
 
   const origQuery = element0.query as IWriteQuery;
 

--- a/lib/looker.ts
+++ b/lib/looker.ts
@@ -14,10 +14,12 @@ export async function getDashboardElement0(
   template: string,
 ): Promise<IDashboardElement> {
   let dashboardId;
-  if (platform === "fenix") {
-    dashboardId = "2303";
-  } else {
-    dashboardId = getDashboardIdForTemplate(template);
+  switch (platform) {
+    case "fenix":
+      dashboardId = "2303";
+      break;
+    default:
+      dashboardId = getDashboardIdForTemplate(template);
   }
 
   // XXX maybe switch this out for the more performant dashboard_element (see
@@ -88,6 +90,7 @@ export async function runQueryForTemplate(
         },
         filters,
       );
+      break;
     default:
       if (template === "infobar") {
         newQueryBody.filters = Object.assign(
@@ -182,7 +185,6 @@ export async function getAndroidCTRPercentData(
   // this code are worth applying some manual performance checking.
   let queryResult;
   if (template === "survey") {
-    console.log("[getAndroidCTRPercentData] platform: " + platform);
     queryResult = await runQueryForTemplate(
       platform,
       template,
@@ -192,7 +194,7 @@ export async function getAndroidCTRPercentData(
         "events_unnested_table__ping_info__experiments.value__branch": branch,
         "events.sample_id": "to 10", // Sample ID <= 10
         "events.event_category": "messaging", // XXX
-        "events_unnested_table__event_extra.value": id + "%",
+        "events_unnested_table__event_extra.value": id.slice(0, -5) + "%",
       },
       startDate,
       endDate,
@@ -233,7 +235,6 @@ export async function getDesktopCTRPercentData(
   // those filters to sync up the data in both places. Non-trivial changes to
   // this code are worth applying some manual performance checking.
   let queryResult;
-  console.log("[getDesktopCTRPercentData] platform: " + platform);
   if (template === "infobar") {
     queryResult = await runQueryForTemplate(
       platform,

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -203,7 +203,7 @@ export function _isAboutWelcomeTemplate(template: string): boolean {
 }
 
 export function getAndroidDashboard(
-  template: string,
+  surface: string,
   msgIdPrefix: string,
   channel?: string,
   experiment?: string,
@@ -220,9 +220,7 @@ export function getAndroidDashboard(
     isCompleted,
   );
 
-  // XXX consider using a similar function like getDashboardIdForTemplate for
-  // android dashboards to get dashboardId
-  const dashboardId = 2303; // messages/push notification
+  const dashboardId = getSurfaceData(surface).lookerDashboardId; // messages/push notification
   let baseUrl = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}`;
   let paramObj;
 
@@ -243,7 +241,7 @@ export function getAndroidDashboard(
   };
 
   // XXX we really handle all messaging surfaces, at least in theory
-  if (template !== "survey") return undefined;
+  if (surface !== "survey") return undefined;
 
   if (paramObj) {
     const params = new URLSearchParams(Object.entries(paramObj));
@@ -272,7 +270,7 @@ export function getDashboard(
     endDate,
     isCompleted,
   );
-  const dashboardId = getDashboardIdForTemplate(template);
+  const dashboardId = getDashboardIdForSurface(template);
   let baseUrl = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}`;
   let paramObj;
 
@@ -354,14 +352,10 @@ export function getPreviewLink(message: any): string {
 
 /**
  * XXX consider moving this function inside looker.ts
- * @returns the Looker dashboard ID for a given message template
+ * @returns the Looker dashboard ID for a given desktop template or mobile surface
  */
-export function getDashboardIdForTemplate(template: string) {
-  if (template === "infobar") {
-    return "2267";
-  } else {
-    return "1818";
-  }
+export function getDashboardIdForSurface(surfaceOrTemplate: string) {
+  return getSurfaceData(surfaceOrTemplate).lookerDashboardId;
 }
 
 /**

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -202,7 +202,7 @@ export function _isAboutWelcomeTemplate(template: string): boolean {
   return aboutWelcomeSurfaces.includes(template);
 }
 
-export function getAndroidDashboard(
+export function getAndroidDashboardLink(
   surface: string,
   msgIdPrefix: string,
   channel?: string,
@@ -253,7 +253,7 @@ export function getAndroidDashboard(
   return undefined;
 }
 
-export function getDashboard(
+export function getDesktopDashboardLink(
   template: string,
   msgId: string,
   channel?: string,

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -137,7 +137,7 @@ export function getAndroidDashboard(
 
   // XXX consider using a similar function like getDashboardIdForTemplate for
   // android dashboards to get dashboardId
-  const dashboardId = 2191; // messages/push notification
+  const dashboardId = 2303; // messages/push notification
   let baseUrl = `https://mozilla.cloud.looker.com/dashboards/${dashboardId}`;
   let paramObj;
 

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -1,97 +1,182 @@
 import { FxMSMessageInfo } from "@/app/columns";
 import { getLookerSubmissionTimestampDateFilter } from "./lookerUtils";
+import { Platform } from "./types";
 
 export type SurfaceData = {
   surface: string;
+  platform: Platform;
+  lookerDateFilterPropertyName: string;
+  lookerDashboardId: string;
   tagColor?: string;
   docs?: string;
 };
 
-export function getSurfaceDataForTemplate(template: string): SurfaceData {
+/**
+ * @param surfaceOrTemplate a desktop template or mobile surface
+ * @returns data pertaining to hte given desktop template or mobile surface
+ * (ie. surface display name, platform, Looker date filter property name,
+ * Looker dashboard ID, surface tag background colour)
+ */
+export function getSurfaceData(surfaceOrTemplate: string): SurfaceData {
   const surfaceData: Record<string, SurfaceData> = {
     aboutwelcome: {
       surface: "About:Welcome Page (1st screen)",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-red-400",
     },
     cfr: {
       surface: "Contextual Feature Recommendation",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-red-200",
     },
     cfr_doorhanger: {
       surface: "Doorhanger",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-orange-200",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#doorhanger",
     },
     defaultaboutwelcome: {
       surface: "Default About:Welcome Message (1st screen)",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-orange-400",
     },
     feature_callout: {
       surface: "Feature Callout (1st screen)",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-yellow-300",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#feature-callouts",
     },
     infobar: {
       surface: "InfoBar",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "messaging_system.submission_date",
+      lookerDashboardId: "2267",
       tagColor: "bg-lime-300",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#infobar",
     },
     menu: {
       surface: "Menu Messages",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-pink-300",
     },
     milestone_message: {
       surface: "Milestone Messages",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-green-400",
     },
     multi: {
       surface: "1st of Multiple Messages",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-teal-300",
     },
     pb_newtab: {
       surface: "Private Browsing New Tab",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-sky-400",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#privatebrowsing",
     },
     protections_panel: {
       surface: "Protections Dropdown Panel",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-blue-500",
     },
     rtamo: {
       surface: "Return to AMO",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-violet-200",
     },
     toast_notification: {
       surface: "Toast Notification",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-indigo-400",
     },
-    toolbar_badge: { surface: "Toolbar Badge", tagColor: "bg-purple-400" },
+    toolbar_badge: {
+      surface: "Toolbar Badge",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
+      tagColor: "bg-purple-400",
+    },
     // XXX Consider removing after we start reading JSON from remote settings
-    "toolbar-badge": { surface: "Toolbar Badge", tagColor: "bg-purple-400" },
+    "toolbar-badge": {
+      surface: "Toolbar Badge",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
+      tagColor: "bg-purple-400",
+    },
     spotlight: {
       surface: "Spotlight Modal Dialog",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-pink-400",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#multistage-spotlight",
     },
     survey: {
       surface: "Survey",
+      platform: "fenix",
+      lookerDateFilterPropertyName: "events.submission_date",
+      lookerDashboardId: "2303",
       tagColor: "bg-cyan-400",
     },
     update_action: {
       surface: "Moments Page",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
       tagColor: "bg-rose-400",
       docs: "https://experimenter.info/messaging/desktop-messaging-surfaces/#moments-pages",
     },
-    "whats-new-panel": { surface: "What's New Panel", tagColor: "bg-sky-200" },
-    whatsNewPage: { surface: "What's New Page", tagColor: "bg-fuchsia-300" },
+    "whats-new-panel": {
+      surface: "What's New Panel",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
+      tagColor: "bg-sky-200",
+    },
+    whatsNewPage: {
+      surface: "What's New Page",
+      platform: "firefox-desktop",
+      lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+      lookerDashboardId: "1818",
+      tagColor: "bg-fuchsia-300",
+    },
   };
 
-  if (template in surfaceData) {
-    return surfaceData[template];
+  if (surfaceOrTemplate in surfaceData) {
+    return surfaceData[surfaceOrTemplate];
   }
 
   return {
-    surface: template,
+    surface: surfaceOrTemplate,
+    platform: "firefox-desktop", // XXX
+    lookerDateFilterPropertyName: "event_counts.submission_timestamp_date", // XXX
+    lookerDashboardId: "1818", // XXX
   };
 }
 

--- a/lib/messageUtils.ts
+++ b/lib/messageUtils.ts
@@ -13,7 +13,7 @@ export type SurfaceData = {
 
 /**
  * @param surfaceOrTemplate a desktop template or mobile surface
- * @returns data pertaining to hte given desktop template or mobile surface
+ * @returns data pertaining to the given desktop template or mobile surface
  * (ie. surface display name, platform, Looker date filter property name,
  * Looker dashboard ID, surface tag background colour)
  */
@@ -174,9 +174,9 @@ export function getSurfaceData(surfaceOrTemplate: string): SurfaceData {
 
   return {
     surface: surfaceOrTemplate,
-    platform: "firefox-desktop", // XXX
-    lookerDateFilterPropertyName: "event_counts.submission_timestamp_date", // XXX
-    lookerDashboardId: "1818", // XXX
+    platform: "firefox-desktop",
+    lookerDateFilterPropertyName: "event_counts.submission_timestamp_date",
+    lookerDashboardId: "1818",
   };
 }
 

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -1,10 +1,10 @@
 import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "../app/columns.jsx";
 import {
-  getAndroidDashboard,
-  getDashboard,
+  getAndroidDashboardLink,
   getSurfaceData,
   getPreviewLink,
   getTemplateFromMessage,
+  getDesktopDashboardLink,
 } from "../lib/messageUtils.ts";
 import {
   getProposedEndDate,
@@ -153,7 +153,7 @@ export class NimbusRecipe implements NimbusRecipeType {
       formattedEndDate = formatDate(branchInfo.nimbusExperiment.endDate, 1);
     }
 
-    branchInfo.ctrDashboardLink = getAndroidDashboard(
+    branchInfo.ctrDashboardLink = getAndroidDashboardLink(
       branchInfo.template as string,
       branchInfo.id,
       undefined,
@@ -364,7 +364,7 @@ export class NimbusRecipe implements NimbusRecipeType {
     if (branchInfo.nimbusExperiment.endDate) {
       formattedEndDate = formatDate(branchInfo.nimbusExperiment.endDate, 1);
     }
-    branchInfo.ctrDashboardLink = getDashboard(
+    branchInfo.ctrDashboardLink = getDesktopDashboardLink(
       branch.template,
       branchInfo.id,
       undefined,

--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -2,7 +2,7 @@ import { BranchInfo, RecipeInfo, RecipeOrBranchInfo } from "../app/columns.jsx";
 import {
   getAndroidDashboard,
   getDashboard,
-  getSurfaceDataForTemplate,
+  getSurfaceData,
   getPreviewLink,
   getTemplateFromMessage,
 } from "../lib/messageUtils.ts";
@@ -118,7 +118,7 @@ export class NimbusRecipe implements NimbusRecipeType {
         const surface = message0.surface;
         // XXX need to rename template & surface somehow
         branchInfo.template = surface;
-        branchInfo.surface = getSurfaceDataForTemplate(surface).surface;
+        branchInfo.surface = getSurfaceData(surface).surface;
 
         switch (surface) {
           case "messages":
@@ -228,7 +228,7 @@ export class NimbusRecipe implements NimbusRecipeType {
 
     branch.template = template;
     branchInfo.template = template;
-    branchInfo.surface = getSurfaceDataForTemplate(template).surface;
+    branchInfo.surface = getSurfaceData(template).surface;
     branchInfo.hasMicrosurvey = _branchInfoHasMicrosurvey(branchInfo);
 
     switch (template) {

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -23,7 +23,7 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
       .getBranchInfos()
       .map(async (branchInfo: BranchInfo): Promise<BranchInfo> => {
         if (branchInfo.nimbusExperiment.appName === "fenix") {
-          console.log(JSON.stringify(branchInfo));
+          console.log(branchInfo.id + ": " + branchInfo.template);
         }
         const proposedEndDate = getExperimentLookerDashboardDate(
           branchInfo.nimbusExperiment.startDate,

--- a/lib/nimbusRecipeCollection.ts
+++ b/lib/nimbusRecipeCollection.ts
@@ -22,6 +22,9 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
     recipe
       .getBranchInfos()
       .map(async (branchInfo: BranchInfo): Promise<BranchInfo> => {
+        if (branchInfo.nimbusExperiment.appName === "fenix") {
+          console.log(JSON.stringify(branchInfo));
+        }
         const proposedEndDate = getExperimentLookerDashboardDate(
           branchInfo.nimbusExperiment.startDate,
           branchInfo.nimbusExperiment.proposedDuration,
@@ -30,6 +33,7 @@ async function updateBranchesCTR(recipe: NimbusRecipe): Promise<BranchInfo[]> {
         // Looker being case sensitive
         const ctrPercentData = await getCTRPercentData(
           branchInfo.id,
+          branchInfo.nimbusExperiment.appName,
           branchInfo.template!,
           undefined,
           branchInfo.nimbusExperiment.slug,


### PR DESCRIPTION
Changes made:
- Updated variables so that we refer to desktop message templates as `template`, android message surfaces as `surface`, and in the case where we get either or, it is referred to as `templateOrSurface`
- Renamed `getAWDashboardElement0` to `getDashboardElement0`
- Turned `getCTRPercentData` into a dispatcher function and added a `getAndroidCTRPercentData` to get the CTR and impressions data for messaging featureIDs 
- Updated `getSurfaceDataForTemplate` to include more properties (ie. platform, lookerDateFilterPropertyName, lookerDashboardId)
- Renamed `getSurfaceDataForTemplate` to `getSurfaceData`
- Renamed `getDashboardIdForTemplate` to `getDashboardIdForSurface`
- Renamed `runQueryForTemplate` to `runQueryForSurface`
- Renamed `getDashboard` to `getDesktopDashboardLink` and `getAndroidDashboard` to `getAndroidDashboardLink`
- Updated tests to account for these changes

Note:
- Adding more tests for `getCTRPercentData` is still a WIP because I'm trying to figure out how to account for the dispatcher function through mocked files 