### PR TITLE
Bandaid broken updates and build issue when multi used with infobar

### DIFF
--- a/lib/nimbusRecipe.ts
+++ b/lib/nimbusRecipe.ts
@@ -328,6 +328,13 @@ export class NimbusRecipe implements NimbusRecipeType {
           return branchInfo;
         }
 
+        if (!("screens" in firstMessage.content)) {
+          console.warn(
+            "multis where the 1st message's content does not have `screens` member (like infobar) are not support",
+          );
+          return branchInfo;
+        }
+
         // XXX only does first screen
         branchInfo.id = firstMessage.content.screens[0].id;
         // Localize the recipe if necessary.


### PR DESCRIPTION
SImply emit a warning and return the partially built branch info instead of crashing.