### PR TITLE
Bump CI node versions from 22/23 to 22/24

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 23.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
We won't ever really update to Node 23; it was just a canary build so that we'd know what was coming down the Pike.  Now that 24 is alive, we'll switch our canary to that.