### PR TITLE
Add catch-all npm group, propose major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,18 @@ updates:
           - "major"
           - "minor"
           - "patch"
+      # catch-all for all other npm packages
+      npm-other:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "*next*"
+          - "eslint-config-next"
+          - "react"
+          - "react-dom"
+          - "@radix-ui/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Right now, dependabot is not proposed major version updates to all npm packages so that we at least become aware of them.  This fixes that.