### PR TITLE
Disable Android, which was hitting limits, to make Desktop current

### DIFF
--- a/app/android/page.tsx
+++ b/app/android/page.tsx
@@ -5,6 +5,11 @@ import { Platform } from "@/lib/types";
 const platform: Platform = "fenix";
 
 export default async function Page() {
+  // XXXdmose We're hitting Looker data limits. Ultimately, we may want an
+  // ErrorBoundary here for the general case, but for now, we'll just return an
+  // empty div to get things working again.
+  return <div />;
+
   const {
     localData,
     experimentAndBranchInfo,


### PR DESCRIPTION
Need to correctly fix the Android dashboards as well as prevent these sorts of errors again, but since Android is currently not in use, disabling it for now to fix Desktop builds.